### PR TITLE
Add baseURL second arg support in test/exec and result.inputs.

### DIFF
--- a/src/url-pattern.interfaces.ts
+++ b/src/url-pattern.interfaces.ts
@@ -13,7 +13,7 @@ export interface URLPatternInit {
 export type URLPatternKeys = keyof URLPatternInit
 
 export interface URLPatternResult {
-  input: URLPatternInit | string;
+  inputs: [URLPatternInit | string];
   protocol: URLPatternComponentResult;
   username: URLPatternComponentResult;
   password: URLPatternComponentResult;


### PR DESCRIPTION
This pull request does the follow:

1. Adds support for passing the base URL in the second argument to `test()` and `exec()` when the first argument is a string.
2. Reflects the arguments back in `URLPatternResult.inputs`.  This replaces the old `input` (singular) property.

This is an incremental step towards fixing #7.