### PR TITLE
Implement pattern canonicalization.

### DIFF
--- a/src/path-to-regex-modified.ts
+++ b/src/path-to-regex-modified.ts
@@ -25,6 +25,10 @@ interface LexToken {
 const regexIdentifierStart = /[$_\p{ID_Start}]/u;
 const regexIdentifierPart = /[$_\u200C\u200D\p{ID_Continue}]/u;
 
+function isASCII(str: string, extended: boolean) {
+  return (extended ? /^[\x00-\xFF]*$/ : /^[\x00-\x7F]*$/).test(str);
+}
+
 /**
  * Tokenize input string.
  */
@@ -104,6 +108,11 @@ export function lexer(str: string, lenient: boolean = false): LexToken[] {
       }
 
       while (j < str.length) {
+        if (!isASCII(str[j], false)) {
+          ErrorOrInvalid(`Invalid character '${str[j]}' at ${j}.`);
+          continue;
+        }
+
         if (str[j] === "\\") {
           pattern += str[j++] + str[j++];
           continue;

--- a/src/url-pattern.ts
+++ b/src/url-pattern.ts
@@ -15,10 +15,7 @@ import {
 
 // The default wildcard pattern used for a component when the constructor
 // input does not provide an explicit value.
-const DEFAULT_PATTERN = '(.*)';
-
-// The default wildcard pattern for the pathname component.
-const DEFAULT_PATHNAME_PATTERN = '/(.*)';
+const DEFAULT_PATTERN = '*';
 
 // default to strict mode and case sensitivity.  In addition, most
 // components have no concept of a delimiter or prefix character.
@@ -271,7 +268,7 @@ export class URLPattern {
       }
 
       const defaults = {
-        pathname: DEFAULT_PATHNAME_PATTERN,
+        pathname: DEFAULT_PATTERN,
         protocol: DEFAULT_PATTERN,
         username: DEFAULT_PATTERN,
         password: DEFAULT_PATTERN,
@@ -344,8 +341,7 @@ export class URLPattern {
 
     let component:URLPatternKeys
     for (component in this.pattern) {
-      const fallback = component == 'pathname' ? '/' : '';
-      if (!this.regexp[component].exec(values[component] || fallback)) {
+      if (!this.regexp[component].exec(values[component] || '')) {
         return false;
       }
     }
@@ -393,8 +389,7 @@ export class URLPattern {
 
     let component: URLPatternKeys;
     for (component in this.pattern) {
-      const fallback = component == 'pathname' ? '/' : '';
-      let match = this.regexp[component].exec(values[component] || fallback);
+      let match = this.regexp[component].exec(values[component] || '');
       if (!match) {
         return null;
       }


### PR DESCRIPTION
(Note, this PR depends on #13 which should be merged first.)

This PR adds canonicalization of pattern strings.  This is done via the
path-to-regexp encode callback feature.  These callbacks are invoked on
plain text parts of the pattern string.  Values within regular
expressions, etc, are not passed to the encode callbacks.  This PR
provides the appropriate encode callback for each component.

In addition, the check for an ASCII regular expression now must be
performed by path-to-regexp itself.  This PR updates the modified
path-to-regexp to do this.  This change is also available in:

https://github.com/wanderview/path-to-regexp/tree/urlpattern-6-ascii-regexp