### PR TITLE
Compile regexp using unicode flag.

### DIFF
--- a/src/path-to-regex-modified.ts
+++ b/src/path-to-regex-modified.ts
@@ -492,7 +492,7 @@ function escapeString(str: string) {
  * Get the flags for a regexp from the options.
  */
 function flags(options?: { sensitive?: boolean }) {
-  return options && options.sensitive ? "" : "i";
+  return options && options.sensitive ? "u" : "ui";
 }
 
 /**


### PR DESCRIPTION
This change is also available in the path-to-regexp fork at:

https://github.com/wanderview/path-to-regexp/tree/urlpattern-4-special-chars