### PR TITLE
Fix pathname canonicalization for input with non-standard protocols.

### DIFF
--- a/src/url-pattern.ts
+++ b/src/url-pattern.ts
@@ -154,7 +154,7 @@ function applyInit(o: URLPatternInit, init: URLPatternInit, isPattern: boolean):
         o.pathname = baseURL.pathname.substring(0, slashIndex + 1) + o.pathname;
       }
     }
-    o.pathname = canonicalizePathname(o.pathname, isPattern);
+    o.pathname = canonicalizePathname(o.pathname, o.protocol, isPattern);
   }
 
   if (typeof init.search === 'string') {
@@ -402,7 +402,7 @@ export class URLPattern {
 
     let component:URLPatternKeys
     for (component in this.pattern) {
-      if (!this.regexp[component].exec(values[component] || '')) {
+      if (!this.regexp[component].exec(values[component])) {
         return false;
       }
     }
@@ -450,7 +450,7 @@ export class URLPattern {
 
     let component: URLPatternKeys;
     for (component in this.pattern) {
-      let match = this.regexp[component].exec(values[component] || '');
+      let match = this.regexp[component].exec(values[component]);
       if (!match) {
         return null;
       }

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -31,19 +31,20 @@ export function isAbsolutePathname(pathname: string, isPattern: boolean): boolea
   return false;
 }
 
+const SPECIAL_SCHEMES = [
+  'ftp',
+  'file',
+  'http',
+  'https',
+  'ws',
+  'wss',
+];
+
 export function isSpecialScheme(protocol_regexp: any) {
   if (!protocol_regexp) {
     return true;
   }
-  const specialSchemes = [
-    'ftp',
-    'file',
-    'http',
-    'https',
-    'ws',
-    'wss',
-  ];
-  for (const scheme of specialSchemes) {
+  for (const scheme of SPECIAL_SCHEMES) {
     if (protocol_regexp.test(scheme)) {
       return true;
     }
@@ -96,9 +97,15 @@ export function canonicalizeUsername(username: string, isPattern: boolean) {
   return url.username;
 }
 
-export function canonicalizePathname(pathname: string, isPattern: boolean) {
+export function canonicalizePathname(pathname: string, protocol: string | undefined,
+                                     isPattern: boolean) {
   if (isPattern || pathname === '') {
     return pathname;
+  }
+
+  if (protocol && !SPECIAL_SCHEMES.includes(protocol)) {
+    const url = new URL(`${protocol}:${pathname}`);
+    return url.pathname;
   }
 
   const leadingSlash = pathname[0] == "/";
@@ -208,8 +215,7 @@ export function pathURLPathnameEncodeCallback(input: string): string {
   if (input === '') {
     return input;
   }
-  const url = new URL('data:example');
-  url.pathname = input;
+  const url = new URL(`data:${input}`);
   return url.pathname;
 }
 


### PR DESCRIPTION
The `test()` and `exec()` methods also perform canonicalization on their
input on a component-by-component basis when the dictionary is passed.
In those cases we must be careful to use the correct type of pathname
canonicalization based on the protocol value.  Special schemes like
'https' get more typical encoding, but schemes like 'data' get a less
strict form of encoding.

This change also cleans up some fallback strings in `test()` and
`exec()` that are no longer needed.