### PR TITLE
Accept prefix/suffix characters on protocol, search, and hash.

### DIFF
--- a/src/path-to-regex-modified.ts
+++ b/src/path-to-regex-modified.ts
@@ -1,7 +1,7 @@
 /**
  * Tokenizer results.
  */
-interface LexToken {
+export interface LexToken {
   type:
     | "OPEN"
     | "CLOSE"
@@ -274,7 +274,10 @@ export function parse(str: string, options: ParseOptions = {}): Token[] {
     if (open) {
       const prefix = consumeText();
       const name = tryConsume("NAME") || "";
-      const pattern = tryConsume("PATTERN") || "";
+      let pattern = tryConsume("PATTERN") || "";
+      if (!name && !pattern && tryConsume("ASTERISK")) {
+        pattern = ".*";
+      }
       const suffix = consumeText();
 
       mustConsume("CLOSE");

--- a/src/path-to-regex-modified.ts
+++ b/src/path-to-regex-modified.ts
@@ -101,6 +101,7 @@ export function lexer(str: string, lenient: boolean = false): LexToken[] {
       let count = 1;
       let pattern = "";
       let j = i + 1;
+      let error = false;
 
       if (str[j] === "?") {
         ErrorOrInvalid(`Pattern cannot start with "?" at ${j}`);
@@ -110,7 +111,8 @@ export function lexer(str: string, lenient: boolean = false): LexToken[] {
       while (j < str.length) {
         if (!isASCII(str[j], false)) {
           ErrorOrInvalid(`Invalid character '${str[j]}' at ${j}.`);
-          continue;
+          error = true;
+          break;
         }
 
         if (str[j] === "\\") {
@@ -128,12 +130,16 @@ export function lexer(str: string, lenient: boolean = false): LexToken[] {
           count++;
           if (str[j + 1] !== "?") {
             ErrorOrInvalid(`Capturing groups are not allowed at ${j}`);
-            continue;
+            error = true;
+            break;
           }
         }
 
         pattern += str[j++];
       }
+
+      if (error)
+        continue;
 
       if (count) {
         ErrorOrInvalid(`Unbalanced pattern at ${i}`);

--- a/src/url-pattern-parser.ts
+++ b/src/url-pattern-parser.ts
@@ -1,0 +1,484 @@
+// The parse has been translated from the chromium c++ implementation at:
+//
+//  https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/url_pattern/url_pattern_parser.h;l=36;drc=f66c35e3c41629675130001dbce0dcfba870160b
+//
+
+import {lexer, LexToken, pathToRegexp, ParseOptions, TokensToRegexpOptions} from './path-to-regex-modified';
+import {URLPatternInit} from './url-pattern.interfaces';
+import {DEFAULT_OPTIONS, protocolEncodeCallback, isSpecialScheme} from './url-utils';
+
+enum State {
+  INIT,
+  PROTOCOL,
+  AUTHORITY,
+  USERNAME,
+  PASSWORD,
+  HOSTNAME,
+  PORT,
+  PATHNAME,
+  SEARCH,
+  HASH,
+  DONE,
+}
+
+// A helper class to parse the first string passed to the URLPattern
+// constructor.  In general the parser works by using the path-to-regexp
+// lexer to first split up the input into pattern tokens.  It can
+// then look through the tokens to find non-special characters that match
+// the different URL component separators.  Each component is then split
+// off and stored in a `URLPatternInit` object that can be accessed via
+// the `Parser.result` getter.  The intent is that this init object should
+// then be processed as if it was passed into the constructor itself.
+export class Parser {
+  // The input string to the parser.
+  private input: string;
+
+  // The list of `LexToken`s produced by the path-to-regexp `lexer()` function
+  // when passed `input` with lenient mode enabled.
+  private tokenList: LexToken[] = [];
+
+  // As we parse the input string we populate a `URLPatternInit` dictionary
+  // with each component pattern.  This is then the final result of the parse.
+  private internalResult: URLPatternInit = {};
+
+  // The index of the current `LexToken` being considered.
+  private tokenIndex: number = 0;
+
+  // The value to add to `tokenIndex` on each turn through the parse loop.
+  // While typically this is `1`, it is also set to `0` at times for things
+  // like state transitions, etc.  It is automatically reset back to `1` at
+  // the top of the parse loop.
+  private tokenIncrement: number = 1;
+
+  // The index of the first `LexToken` to include in the component string.
+  private componentStart: number = 0;
+
+  // The current parse state.  This should only be changed via `changeState()`
+  // or `rewindAndSetState()`.
+  private state: State = State.INIT;
+
+  // The current nest depth of `{ }` pattern groupings.
+  private groupDepth: number = 0;
+
+  // True if we should apply parse rules as if this is a "standard" URL.  If
+  // false then this is treated as a "not a base URL".
+  private shouldTreatAsStandardURL: boolean = false;
+
+  public constructor(input: string) {
+    this.input = input;
+  }
+
+  // Return the parse result.  The result is only available after the
+  // `parse()` method completes.
+  public get result(): URLPatternInit {
+    return this.internalResult;
+  }
+
+  // Attempt to parse the input string used to construct the Parser object.
+  // This method may only be called once.  Any errors will be thrown as an
+  // exception.  Retrieve the parse result by accessing the `Parser.result`
+  // property getter.
+  public parse(): void {
+    this.tokenList = lexer(this.input, /*lenient=*/true);
+
+    for (; this.tokenIndex < this.tokenList.length;
+         this.tokenIndex += this.tokenIncrement) {
+      // Reset back to our default tokenIncrement value.
+      this.tokenIncrement = 1;
+
+      // All states must respect the end of the token list.  The path-to-regexp
+      // lexer guarantees that the last token will have the type `END`.
+      if (this.tokenList[this.tokenIndex].type === 'END') {
+        // If we failed to find a protocol terminator then we are still in
+        // relative mode.  We now need to determine the first component of the
+        // relative URL.
+        if (this.state === State.INIT) {
+          // Reset back to the start of the input string.
+          this.rewind();
+
+          // If the string begins with `?` then its a relative search component.
+          // If it starts with `#` then its a relative hash component.  Otherwise
+          // its a relative pathname.
+          if (this.isHashPrefix()) {
+            this.changeState(State.HASH, /*skip=*/1);
+          } else if (this.isSearchPrefix()) {
+            this.changeState(State.SEARCH, /*skip=*/1);
+            this.internalResult.hash = '';
+          } else {
+            this.changeState(State.PATHNAME, /*skip=*/0);
+            this.internalResult.search = '';
+            this.internalResult.hash = '';
+          }
+          continue;
+        }
+        //
+        // If we failed to find an `@`, then there is no username and password.
+        // We should rewind and process the data as a hostname.
+        else if (this.state === State.AUTHORITY) {
+          this.rewindAndSetState(State.HOSTNAME);
+          continue;
+        }
+
+        this.changeState(State.DONE, /*skip=*/0);
+        break;
+      }
+
+      // In addition, all states must handle pattern groups.  We do not permit
+      // a component to end in the middle of a pattern group.  Therefore we skip
+      // past any tokens that are within `{` and `}`.  Note, the tokenizer
+      // handles group `(` and `)` and `:foo` groups for us automatically, so
+      // we don't need special code for them here.
+      if (this.groupDepth > 0) {
+        if (this.isGroupClose()) {
+          this.groupDepth -= 1;
+        } else {
+          continue;
+        }
+      }
+
+      if (this.isGroupOpen()) {
+        this.groupDepth += 1;
+        continue;
+      }
+
+      switch (this.state) {
+        case State.INIT:
+          if (this.isProtocolSuffix()) {
+            // We are in absolute mode and we know values will not be inherited
+            // from a base URL.  Therefore initialize the rest of the components
+            // to the empty string.
+            this.internalResult.username = '';
+            this.internalResult.password = '';
+            this.internalResult.hostname = '';
+            this.internalResult.port = '';
+            this.internalResult.pathname = '';
+            this.internalResult.search = '';
+            this.internalResult.hash = '';
+
+            // Update the state to expect the start of an absolute URL.
+            this.rewindAndSetState(State.PROTOCOL);
+          }
+          break;
+
+        case State.PROTOCOL:
+          // If we find the end of the protocol component...
+          if (this.isProtocolSuffix()) {
+            // First we eagerly compile the protocol pattern and use it to
+            // compute if this entire URLPattern should be treated as a
+            // "standard" URL.  If any of the special schemes, like `https`,
+            // match the protocol pattern then we treat it as standard.
+            this.computeShouldTreatAsStandardURL();
+
+            // By default we treat this as a "cannot-be-a-base-URL" or what chrome
+            // calls a "path" URL.  In this case we go straight to the pathname
+            // component.  The hostname and port are left with their default
+            // empty string values.
+            let nextState: State = State.PATHNAME;
+            let skip: number = 1;
+
+            if (this.shouldTreatAsStandardURL) {
+              this.internalResult.pathname = '/';
+            }
+
+            // If there are authority slashes, like `https://`, then
+            // we must transition to the authority section of the URLPattern.
+            if (this.nextIsAuthoritySlashes()) {
+              nextState = State.AUTHORITY;
+              skip = 3;
+            }
+
+            // If there are no authority slashes, but the protocol is special
+            // then we still go to the authority section as this is a "standard"
+            // URL.  This differs from the above case since we don't need to skip
+            // the extra slashes.
+            else if (this.shouldTreatAsStandardURL) {
+              nextState = State.AUTHORITY;
+            }
+
+            this.changeState(nextState, skip);
+          }
+          break;
+
+        case State.AUTHORITY:
+          // Before going to the hostname state we must see if there is an
+          // identity of the form:
+          //
+          //  <username>:<password>@<hostname>
+          //
+          // We check for this by looking for the `@` character.  The username
+          // and password are themselves each optional, so the `:` may not be
+          // present.  If we see the `@` we just go to the username state
+          // and let it proceed until it hits either the password separator
+          // or the `@` terminator.
+          if (this.isIdentityTerminator()) {
+            this.rewindAndSetState(State.USERNAME);
+          }
+
+          // Stop searching for the `@` character if we see the beginning
+          // of the pathname, search, or hash components.
+          else if (this.isPathnameStart() || this.isSearchPrefix() ||
+                   this.isHashPrefix()) {
+            this.rewindAndSetState(State.HOSTNAME);
+          }
+          break;
+
+        case State.USERNAME:
+          // If we find a `:` then transition to the password component state.
+          if (this.isPasswordPrefix()) {
+            this.changeState(State.PASSWORD, /*skip=*/1);
+          }
+
+          // If we find a `@` then transition to the hostname component state.
+          else if (this.isIdentityTerminator()) {
+            this.changeState(State.HOSTNAME, /*skip=*/1);
+          }
+          break;
+
+        case State.PASSWORD:
+          // If we find a `@` then transition to the hostname component state.
+          if (this.isIdentityTerminator()) {
+            this.changeState(State.HOSTNAME, /*skip=*/1);
+          }
+          break;
+
+        case State.HOSTNAME:
+          // If we find a `:` then we transition to the port component state.
+          if (this.isPortPrefix()) {
+            this.changeState(State.PORT, /*skip=*/1);
+          }
+
+          // If we find a `/` then we transition to the pathname component state.
+          else if (this.isPathnameStart()) {
+            this.changeState(State.PATHNAME, /*skip=*/0);
+          }
+
+          // If we find a `?` then we transition to the search component state.
+          else if (this.isSearchPrefix()) {
+            this.changeState(State.SEARCH, /*skip=*/1);
+          }
+
+          // If we find a `#` then we transition to the hash component state.
+          else if (this.isHashPrefix()) {
+            this.changeState(State.HASH, /*skip=*/1);
+          }
+          break;
+
+        case State.PORT:
+          // If we find a `/` then we transition to the pathname component state.
+          if (this.isPathnameStart()) {
+            this.changeState(State.PATHNAME, /*skip=*/0);
+          }
+
+          // If we find a `?` then we transition to the search component state.
+          else if (this.isSearchPrefix()) {
+            this.changeState(State.SEARCH, /*skip=*/1);
+          }
+
+          // If we find a `#` then we transition to the hash component state.
+          else if (this.isHashPrefix()) {
+            this.changeState(State.HASH, /*skip=*/1);
+          }
+          break;
+
+        case State.PATHNAME:
+          // If we find a `?` then we transition to the search component state.
+          if (this.isSearchPrefix()) {
+            this.changeState(State.SEARCH, /*skip=*/1);
+          }
+
+          // If we find a `#` then we transition to the hash component state.
+          else if (this.isHashPrefix()) {
+            this.changeState(State.HASH, /*skip=*/1);
+          }
+          break;
+
+        case State.SEARCH:
+          // If we find a `#` then we transition to the hash component state.
+          if (this.isHashPrefix()) {
+            this.changeState(State.HASH, /*skip=*/1);
+          }
+          break;
+
+        case State.HASH:
+          // Nothing to do here as we are just looking for the end.
+          break;
+
+        case State.DONE:
+          // This should not be reached.
+          break;
+      }
+    }
+  }
+
+  private changeState(newState: State, skip: number): void {
+    switch (this.state) {
+      case State.INIT:
+        // No component to set when transitioning from this state.
+        break;
+      case State.PROTOCOL:
+        this.internalResult.protocol = this.makeComponentString();
+        break;
+      case State.AUTHORITY:
+        // No component to set when transitioning from this state.
+        break;
+      case State.USERNAME:
+        this.internalResult.username = this.makeComponentString();
+        break;
+      case State.PASSWORD:
+        this.internalResult.password = this.makeComponentString();
+        break;
+      case State.HOSTNAME:
+        this.internalResult.hostname = this.makeComponentString();
+        break;
+      case State.PORT:
+        this.internalResult.port = this.makeComponentString();
+        break;
+      case State.PATHNAME:
+        this.internalResult.pathname = this.makeComponentString();
+        break;
+      case State.SEARCH:
+        this.internalResult.search = this.makeComponentString();
+        break;
+      case State.HASH:
+        this.internalResult.hash = this.makeComponentString();
+        break;
+      case State.DONE:
+        // No component to set when transitioning from this state.
+        break;
+    }
+
+    this.changeStateWithoutSettingComponent(newState, skip);
+  }
+
+  private changeStateWithoutSettingComponent(newState: State, skip: number): void {
+    this.state = newState;
+
+    // Now update `componentStart` to point to the new component.  The `skip`
+    // argument tells us how many tokens to ignore to get to the next start.
+    this.componentStart = this.tokenIndex + skip;
+
+    // Next, move the `tokenIndex` so that the top of the loop will begin
+    // parsing the new component.
+    this.tokenIndex += skip;
+    this.tokenIncrement = 0;
+  }
+
+  private rewind(): void {
+    this.tokenIndex = this.componentStart;
+    this.tokenIncrement = 0;
+  }
+
+  private rewindAndSetState(newState: State): void {
+    this.rewind();
+    this.state = newState;
+  }
+
+  private safeToken(index: number): LexToken {
+    if (index < 0) {
+      index = this.tokenList.length - index;
+    }
+
+    if (index < this.tokenList.length) {
+      return this.tokenList[index];
+    }
+    return this.tokenList[this.tokenList.length - 1];
+  }
+
+  private isNonSpecialPatternChar(index: number, value: string): boolean {
+    const token: LexToken = this.safeToken(index);
+    return token.value === value &&
+      (token.type === 'CHAR' ||
+       token.type === 'ESCAPED_CHAR' ||
+       token.type === 'INVALID_CHAR');
+  }
+
+  private isProtocolSuffix(): boolean {
+    return this.isNonSpecialPatternChar(this.tokenIndex, ':');
+  }
+
+  private nextIsAuthoritySlashes(): boolean {
+    return this.isNonSpecialPatternChar(this.tokenIndex + 1, '/') &&
+           this.isNonSpecialPatternChar(this.tokenIndex + 2, '/');
+  }
+
+  private isIdentityTerminator(): boolean {
+    return this.isNonSpecialPatternChar(this.tokenIndex, '@');
+  }
+
+  private isPasswordPrefix(): boolean {
+    return this.isNonSpecialPatternChar(this.tokenIndex, ':');
+  }
+
+  private isPortPrefix(): boolean {
+    return this.isNonSpecialPatternChar(this.tokenIndex, ':');
+  }
+
+  private isPathnameStart(): boolean {
+    return this.isNonSpecialPatternChar(this.tokenIndex, '/');
+  }
+
+  private isSearchPrefix(): boolean {
+    if (this.isNonSpecialPatternChar(this.tokenIndex, '?')) {
+      return true;
+    }
+
+    if (this.tokenList[this.tokenIndex].value !== '?') {
+      return false;
+    }
+
+    // We have a `?` tokenized as a modifer.  We only want to treat this as
+    // the search prefix if it would not normally be valid in a path-to-regexp
+    // string.  A modifier must follow a matching group.  Therefore we inspect
+    // the preceding token to if the `?` is immediately following a group
+    // construct.
+    //
+    // So if the string is:
+    //
+    //  https://exmaple.com/foo?bar
+    //
+    // Then we return true because the previous token is a `o` with type `CHAR`.
+    // For the string:
+    //
+    //  https://example.com/:name?bar
+    //
+    // Then we return false because the previous token is `:name` with type
+    // `NAME`.  If the developer intended this to be a search prefix then they
+    // would need to escape the quest mark like `:name\\?bar`.
+    //
+    // Note, if `tokenIndex` is zero the index will wrap around and
+    // `safeToken()` will return the `END` token.  This will correctly return
+    // true from this method as a pattern cannot normally begin with an
+    // unescaped `?`.
+    const previousToken: LexToken = this.safeToken(this.tokenIndex - 1);
+    return previousToken.type !== 'NAME' &&
+           previousToken.type !== 'PATTERN' &&
+           previousToken.type !== 'CLOSE' &&
+           previousToken.type !== 'ASTERISK';
+  }
+
+  private isHashPrefix(): boolean {
+    return this.isNonSpecialPatternChar(this.tokenIndex, '#');
+  }
+
+  private isGroupOpen(): boolean {
+    return this.tokenList[this.tokenIndex].type == 'OPEN';
+  }
+
+  private isGroupClose(): boolean {
+    return this.tokenList[this.tokenIndex].type == 'CLOSE';
+  }
+
+  private makeComponentString(): string {
+    const token: LexToken = this.tokenList[this.tokenIndex];
+    const componentCharStart = this.safeToken(this.componentStart).index;
+    return this.input.substring(componentCharStart, token.index);
+  }
+
+  private computeShouldTreatAsStandardURL(): void {
+    const options: TokensToRegexpOptions & ParseOptions = {};
+    Object.assign(options, DEFAULT_OPTIONS);
+    options.encodePart = protocolEncodeCallback;
+    const regexp = pathToRegexp(this.makeComponentString(), /*keys=*/undefined, options);
+    this.shouldTreatAsStandardURL = isSpecialScheme(regexp);
+  }
+}

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -108,9 +108,7 @@ export function canonicalizeHostname(hostname: string, isPattern: boolean) {
   if (isPattern || hostname === '') {
     return hostname;
   }
-  const url = new URL("https://example.com");
-  url.hostname = hostname;
-  return url.hostname;
+  return hostnameEncodeCallback(hostname);
 }
 
 export function canonicalizePassword(password: string, isPattern: boolean) {
@@ -216,6 +214,9 @@ export function passwordEncodeCallback(input: string): string {
 export function hostnameEncodeCallback(input: string): string {
   if (input === '') {
     return input;
+  }
+  if (/[#%/:<>?@[\]\\|]/g.test(input)) {
+    throw(new TypeError(`Invalid hostname '${input}'`));
   }
   const url = new URL('https://example.com');
   url.hostname = input;

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -1,3 +1,37 @@
+import {ParseOptions, TokensToRegexpOptions} from './path-to-regex-modified';
+
+// default to strict mode and case sensitivity.  In addition, most
+// components have no concept of a delimiter or prefix character.
+export const DEFAULT_OPTIONS: TokensToRegexpOptions & ParseOptions = {
+  delimiter: '',
+  prefixes: '',
+  sensitive: true,
+  strict: true,
+};
+
+// The options to use for hostname patterns.  This uses a
+// "." delimiter controlling how far a named group like ":bar" will match
+// by default.  Note, hostnames are case insensitive but we require case
+// sensitivity here.  This assumes that the hostname values have already
+// been normalized to lower case as in URL().
+export const HOSTNAME_OPTIONS: TokensToRegexpOptions & ParseOptions = {
+  delimiter: '.',
+  prefixes: '',
+  sensitive: true,
+  strict: true,
+};
+
+// The options to use for pathname patterns.  This uses a
+// "/" delimiter controlling how far a named group like ":bar" will match
+// by default.  It also configures "/" to be treated as an automatic
+// prefix before groups.
+export const PATHNAME_OPTIONS: TokensToRegexpOptions & ParseOptions = {
+  delimiter: '/',
+  prefixes: '/',
+  sensitive: true,
+  strict: true,
+};
+
 // Utility function to determine if a pathname is absolute or not.  For
 // URL values this mainly consists of a check for a leading slash.  For
 // patterns we do some additional checking for escaped or grouped slashes.
@@ -31,7 +65,7 @@ export function isAbsolutePathname(pathname: string, isPattern: boolean): boolea
   return false;
 }
 
-const SPECIAL_SCHEMES = [
+export const SPECIAL_SCHEMES = [
   'ftp',
   'file',
   'http',

--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -65,6 +65,20 @@ export function isAbsolutePathname(pathname: string, isPattern: boolean): boolea
   return false;
 }
 
+function maybeStripPrefix(value: string, prefix: string): string {
+  if (value.startsWith(prefix)) {
+    return value.substring(prefix.length, value.length);
+  }
+  return value;
+}
+
+function maybeStripSuffix(value: string, suffix: string): string {
+  if (value.endsWith(suffix)) {
+    return value.substr(0, value.length - suffix.length);
+  }
+  return value;
+}
+
 export const SPECIAL_SCHEMES = [
   'ftp',
   'file',
@@ -87,6 +101,7 @@ export function isSpecialScheme(protocol_regexp: any) {
 }
 
 export function canonicalizeHash(hash: string, isPattern: boolean) {
+  hash = maybeStripPrefix(hash, '#');
   if (isPattern || hash === '') {
     return hash;
   }
@@ -96,6 +111,7 @@ export function canonicalizeHash(hash: string, isPattern: boolean) {
 }
 
 export function canonicalizeSearch(search: string, isPattern: boolean) {
+  search = maybeStripPrefix(search, '?');
   if (isPattern || search === '') {
     return search;
   }
@@ -162,6 +178,8 @@ export function canonicalizePort(port: string, protocol: string | undefined, isP
 }
 
 export function canonicalizeProtocol(protocol: string, isPattern: boolean) {
+  protocol = maybeStripSuffix(protocol, ':');
+
   if (isPattern || protocol === '') {
     return protocol;
   }


### PR DESCRIPTION
(This pull request depends on #21.  Please merge that first.)

This commit also brings path-to-regex up-to-date with another fix committed to the upstream branch.
