### PR TITLE
Add a types field

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "unpkg": "./dist/index.umd.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "src",
     "dist"


### PR DESCRIPTION
See https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#including-declarations-in-your-npm-package

I noticed that Visual Studio wouldn't find the published types when installed via `npm` without this.