### PR TITLE
Throw on duplicate name within a component pattern string (Fixes #31,…

### DIFF
--- a/urlpatterntestdata.json
+++ b/urlpatterntestdata.json
@@ -2110,6 +2110,10 @@
     }
   },
   {
+    "pattern": [{ "pathname": "/:id/:id" }],
+    "expected_obj": "error"
+  },
+  {
     "pattern": [{ "pathname": "/foo", "baseURL": "" }],
     "expected_obj": "error"
   },


### PR DESCRIPTION
… #27)

This commit updates the path-to-regexp version to match the upstream
changs in these branches:

https://github.com/wanderview/path-to-regexp/tree/urlpattern-8-dupe-name
https://github.com/wanderview/path-to-regexp/tree/urlpattern-9-combine-fixed

Updating the path-to-regexp also fixes #27 in passing.