### PR TITLE
Remove console errors

### DIFF
--- a/src/url-pattern.ts
+++ b/src/url-pattern.ts
@@ -377,7 +377,6 @@ export class URLPattern {
       }
     } catch (err) {
       // Treat exceptions simply as a failure to match.
-      console.error(err.message);
       return false;
     }
 
@@ -419,7 +418,6 @@ export class URLPattern {
       }
     } catch (err) {
       // Treat exceptions simply as a failure to match.
-      console.error(err.message);
       return null;
     }
 


### PR DESCRIPTION
Avoid displaying errors in the browser console in non-error scenarios (`test`ing or `exec`-ing against an invalid URL, which simply returns `false` or `null`, respectively)