### PR TITLE
Fix matched values for `:name*` patterns. (#126)

### DIFF
--- a/src/path-to-regex-modified.ts
+++ b/src/path-to-regex-modified.ts
@@ -655,7 +655,11 @@ export function tokensToRegexp(
             route += `(?:${prefix}(${token.pattern})${suffix})${token.modifier}`;
           }
         } else {
-          route += `(${token.pattern})${token.modifier}`;
+          if (token.modifier === "+" || token.modifier === "*") {
+            route += `((?:${token.pattern})${token.modifier})`;
+          } else {
+            route += `(${token.pattern})${token.modifier}`;
+          }
         }
       } else {
         route += `(?:${prefix}${suffix})${token.modifier}`;

--- a/urlpatterntestdata.json
+++ b/urlpatterntestdata.json
@@ -2254,6 +2254,48 @@
     "expected_obj": "error"
   },
   {
+    "pattern": [{ "pathname": ":name*" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":name+" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "pathname": ":name" }],
+    "inputs": [{ "pathname": "foobar" }],
+    "expected_match": {
+      "pathname": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":name*" }],
+    "inputs": [{ "protocol": "foobar" }],
+    "expected_match": {
+      "protocol": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":name+" }],
+    "inputs": [{ "protocol": "foobar" }],
+    "expected_match": {
+      "protocol": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
+    "pattern": [{ "protocol": ":name" }],
+    "inputs": [{ "protocol": "foobar" }],
+    "expected_match": {
+      "protocol": { "input": "foobar", "groups": { "name": "foobar" }}
+    }
+  },
+  {
     "pattern": [{}],
     "inputs": ["https://example.com/"],
     "expected_match": {


### PR DESCRIPTION
This fixes the problem where:

  const p = new URLPattern({ pathname: ':name*' });
  const r = p.exec('foobar');
  console.log(r.pathname.groups.name);

Would log 'r' instead of 'foobar'.

This is an upstream bug in path-to-regexp:

  https://github.com/pillarjs/path-to-regexp/issues/260

This commit essentially applies the proposed fix in:

  https://github.com/pillarjs/path-to-regexp/pull/261

And adds the WPT tests from:

  https://chromium-review.googlesource.com/c/chromium/src/+/3123654