### PR TITLE
Throw on more illegal hostname code points. (#43)

### DIFF
--- a/src/url-utils.ts
+++ b/src/url-utils.ts
@@ -254,7 +254,7 @@ export function hostnameEncodeCallback(input: string): string {
   if (input === '') {
     return input;
   }
-  if (/[#%/:<>?@[\]\\|]/g.test(input)) {
+  if (/[\t\n\r #%/:<>?@[\]^\\|]/g.test(input)) {
     throw(new TypeError(`Invalid hostname '${input}'`));
   }
   const url = new URL('https://example.com');

--- a/urlpatterntestdata.json
+++ b/urlpatterntestdata.json
@@ -2296,6 +2296,74 @@
     }
   },
   {
+    "pattern": [{ "hostname": "bad hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad#hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad%hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad/hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad\\:hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad<hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad>hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad?hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad@hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad[hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad]hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad\\\\hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad^hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad|hostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad\nhostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad\rhostname" }],
+    "expected_obj": "error"
+  },
+  {
+    "pattern": [{ "hostname": "bad\thostname" }],
+    "expected_obj": "error"
+  },
+  {
     "pattern": [{}],
     "inputs": ["https://example.com/"],
     "expected_match": {


### PR DESCRIPTION
This makes the polyfill better conform to the list of forbidden hostname
characters listed in the URL spec:

  https://url.spec.whatwg.org/#forbidden-host-code-point

This change corresponds to this implementation commit:

  https://chromium-review.googlesource.com/c/chromium/src/+/3152036