### PR TITLE
Remove erroneous prefix check when generating pattern string. (#62)

### DIFF
--- a/src/url-pattern.ts
+++ b/src/url-pattern.ts
@@ -208,7 +208,7 @@ function tokensToPattern(tokens: Token[],
     //    b. A plain text expression following a `:foo` group where the text
     //       could be mistakenly interpreted as part of the name.  We want to
     //       output `{:foo}bar` and not `:foobar`.
-    if (!needsGrouping && token.prefix === "" && customName &&
+    if (!needsGrouping && customName &&
         token.pattern === segmentWildcardPattern &&
         token.modifier === "" && nextToken && !nextToken.prefix &&
         !nextToken.suffix) {

--- a/urlpatterntestdata.json
+++ b/urlpatterntestdata.json
@@ -2707,5 +2707,15 @@
     "expected_match": {
       "pathname": { "input": "bar../", "groups": { "foo": "bar" }}
     }
+  },
+  {
+    "pattern": [{ "pathname": "/:foo\\bar" }],
+    "inputs": [{ "pathname": "/bazbar" }],
+    "expected_obj": {
+      "pathname": "{/:foo}bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "/bazbar", "groups": { "foo": "baz" }}
+    }
   }
 ]


### PR DESCRIPTION
This addresses another issue from WICG/urlpattern#161.  It
corresponds to this implementation CL:

https://chromium-review.googlesource.com/c/chromium/src/+/3405148