### PR TITLE
Update package.json exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,17 @@
     "type": "git",
     "url": "https://github.com/kenchris/urlpattern-polyfill"
   },
-  "main": "./dist/index.umd.js",
+  "main": "./dist/index.cjs",
   "module": "./dist/index.js",
   "unpkg": "./dist/index.umd.js",
   "types": "./dist/index.d.ts",
-  "exports": "./dist/index.js",
-  "type": "module",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "node": "./dist/index.cjs",
+      "browser": "./dist/index.umd.js"
+    }
+  },
   "files": [
     "src",
     "dist"

--- a/package.json
+++ b/package.json
@@ -13,8 +13,9 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "node": "./dist/index.cjs",
-      "browser": "./dist/index.umd.js"
+      "require": "./dist/index.cjs",
+      "browser": "./dist/index.umd.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
The current setup in package.json looked problematic to me, and was causing errors when this package was `require`d.

- `main` should point at a `.cjs`, not a file exporting ESM.
- I've added conditions for the `exports` field so that every method of importing knows which file to use.
- I've removed `"type": "module"` as this forces the package to be interpreted as a standard module, no matter how it is imported/required.