### PR TITLE
small improvement to bundling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .vscode
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -17,27 +17,22 @@
   ],
   "devDependencies": {
     "ava": "^3.14.0",
-    "esbuild": "^0.14.30",
-    "esm": "^3.2.25",
+    "esbuild": "^0.14.31",
     "rimraf": "^3.0.2",
     "typescript": "^4.6.3"
   },
   "scripts": {
     "prebuild": "rimraf dist",
-    "build:esm": "esbuild --bundle --format=esm src/index.ts --outfile=dist/index.impl.js && esbuild --format=esm src/patch-global.ts --outfile=dist/index.js",
-    "build:cjs": "esbuild --bundle --format=cjs src/index.ts --outfile=dist/index.impl.cjs && esbuild --format=cjs src/patch-global-cjs.ts --outfile=dist/index.cjs",
+    "build:esm": "esbuild --bundle --format=esm src/url-pattern.ts --outfile=dist/url-pattern.mjs && esbuild --format=esm src/patch-global.mts --outfile=dist/index.js",
+    "build:cjs": "esbuild --bundle --format=cjs src/url-pattern.ts --outfile=dist/url-pattern.cjs && esbuild --format=cjs src/patch-global.cts --outfile=dist/index.cjs",
+ 
     "copy:dts": "cp ./src/index.d.ts ./dist",
     "build": "npm run build:esm && npm run build:cjs && npm run copy:dts",
     "pretest": "npm run build",
     "test": "ava --fail-fast -s",
     "publish-dev": "npm test && VERSION=${npm_package_version%-*}-dev.`git rev-parse --short HEAD` && npm version --no-git-tag-version $VERSION && npm publish --tag dev"
   },
-  "ava": {
-    "require": [
-      "esm"
-    ]
-  },
+
   "author": "",
-  "license": "MIT",
-  "dependencies": {}
+  "license": "MIT"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,0 @@
-import { URLPattern } from './url-pattern';
-
-export { URLPattern };

--- a/src/patch-global.cts
+++ b/src/patch-global.cts
@@ -1,5 +1,5 @@
-import { URLPattern } from "./index.impl.cjs";
 
 if (!globalThis.URLPattern) {
+  const {URLPattern} = require("./url-pattern.cjs");
   globalThis.URLPattern = URLPattern;
 }

--- a/src/patch-global.mts
+++ b/src/patch-global.mts
@@ -1,4 +1,4 @@
-import { URLPattern } from "./index.impl.js";
+import { URLPattern } from "./url-pattern.mjs";
 
 if (!globalThis.URLPattern) {
   globalThis.URLPattern = URLPattern;

--- a/test/can-load-as-cms.cjs
+++ b/test/can-load-as-cms.cjs
@@ -1,0 +1,10 @@
+
+require( "../dist/index.cjs");
+const test  = require( "ava"); 
+
+const baseURL = 'https://example.com';
+
+test('urlPattern', t => {
+  let pattern = new URLPattern({baseURL, pathname: '/product/*?'});
+  t.true(pattern.test(baseURL + '/product/a/b'));
+});

--- a/test/can-load-as-esm.mjs
+++ b/test/can-load-as-esm.mjs
@@ -1,0 +1,10 @@
+import "../dist/index.js";
+import  test  from "ava";
+
+const baseURL = 'https://example.com';
+
+
+test('urlPattern', t => {
+  let pattern = new URLPattern({baseURL, pathname: '/product/*?'});
+  t.true(pattern.test(baseURL + '/product/a/b'));
+});


### PR DESCRIPTION
updated build to provide more clear naming for output files
Remove unneeded ESM package,
Add esbuild package
Use mjs/cjs extensions for the patch-global.*
add tests to see if cjs/esm loads an works.
