### PR TITLE
Readme: fix imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,11 @@ The polyfill works in browsers (ESM module) and in Node.js either via import (ES
 The polyfill will only be loaded if the URLPattern doesn't already exist on the global object, and in that case it will add it to the global object.
 
 ```javascript
-// CJS module loading (Node.js)
+// CJS module loading
 require("urlpattern-polyfill");
 
-// ESM module loading (Node.js)
-import from "urlpattern-polyfill";
-
-// ESM module loading (browsers)
-import from "urlpattern-polyfill/dist/index.js";
+// ESM module loading
+import "urlpattern-polyfill";
 ```
 
 Basic example


### PR DESCRIPTION
The code is incorrect (`import from` is invalid) and browsers don't actually support the suggested line, you'd have to specify the whole import path including `./node_modules`, but most people don't use it that way, so there's no need to specify that.