### PR TITLE
Export URLPattern in CJS file too

### DIFF
--- a/src/patch-global.cts
+++ b/src/patch-global.cts
@@ -1,6 +1,5 @@
+const {URLPattern} = require("./url-pattern.cjs");
+
 if (!globalThis.URLPattern) {
-  const {URLPattern} = require("./url-pattern.cjs");
   globalThis.URLPattern = URLPattern;
 }
-
-exports.URLPattern = URLPattern;

--- a/src/patch-global.cts
+++ b/src/patch-global.cts
@@ -1,5 +1,6 @@
-
 if (!globalThis.URLPattern) {
   const {URLPattern} = require("./url-pattern.cjs");
   globalThis.URLPattern = URLPattern;
 }
+
+exports.URLPattern = URLPattern;


### PR DESCRIPTION
Both entry points should export the same thing, or else `import {URLPattern}` only works if the bundler reads the ESM file, which may decide not to.