### PR TITLE
unify API in esm and CJS implementations

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "scripts": {
     "prebuild": "rimraf dist",
     "build:esm": "esbuild --bundle --format=esm src/patch-global.mts --outfile=dist/index.js",
-    "build:cjs": "esbuild --bundle --format=cjs src/url-pattern.ts --outfile=dist/url-pattern.cjs && esbuild --format=cjs src/patch-global.cts --outfile=dist/index.cjs",
+    "build:cjs": "esbuild --bundle --format=cjs src/patch-global.cts --outfile=dist/index.cjs",
     "copy:dts": "cp ./src/index.d.ts ./dist",
     "build": "npm run build:esm && npm run build:cjs && npm run copy:dts",
     "pretest": "npm run build",

--- a/src/patch-global.cts
+++ b/src/patch-global.cts
@@ -1,5 +1,5 @@
 
-const {URLPattern} = require("./url-pattern.cjs");
+export const {URLPattern} = require("./url-pattern");
 
 if (!globalThis.URLPattern) {
   globalThis.URLPattern = URLPattern;

--- a/test/can-load-as-cms.cjs
+++ b/test/can-load-as-cms.cjs
@@ -8,3 +8,8 @@ test('urlPattern', t => {
   let pattern = new URLPattern({baseURL, pathname: '/product/*?'});
   t.true(pattern.test(baseURL + '/product/a/b'));
 });
+
+test('exports urlPattern', t => {
+  const { URLPattern } = require('../dist/index.cjs');
+  t.true(typeof URLPattern === 'function');
+})


### PR DESCRIPTION
In this PR we update the commonJS implementation to be exactly the same as the ESM version.
Both now are 1 file, that will update the global with URLPattern if its not there,
and both export the URLPattern class too.

This makes it possible to use them both in the same way