### PR TITLE
Add ponyfill export

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -1,4 +1,4 @@
-const { URLPattern } = require("./dist/url-pattern.cjs");
+const { URLPattern } = require("./dist/urlpattern.cjs");
 
 module.exports = { URLPattern };
 

--- a/index.cjs
+++ b/index.cjs
@@ -1,0 +1,7 @@
+const { URLPattern } = require("./dist/pony.cjs");
+
+module.exports = { URLPattern };
+
+if (!globalThis.URLPattern) {
+  globalThis.URLPattern = URLPattern;
+}

--- a/index.cjs
+++ b/index.cjs
@@ -1,4 +1,4 @@
-const { URLPattern } = require("./dist/pony.cjs");
+const { URLPattern } = require("./dist/url-pattern.cjs");
 
 module.exports = { URLPattern };
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { URLPattern } from "./dist/pony.js";
+import { URLPattern } from "./dist/url-pattern.js";
 
 export { URLPattern };
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-import { URLPattern } from "./dist/url-pattern.js";
+import { URLPattern } from "./dist/urlpattern.js";
 
 export { URLPattern };
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
+import { URLPattern } from "./dist/pony.js";
 
-export const {URLPattern} = require("./url-pattern");
+export { URLPattern };
 
 if (!globalThis.URLPattern) {
   globalThis.URLPattern = URLPattern;

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "module": "./index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    "./pony": {
-      "import": "./dist/pony.js",
-      "require": "./dist/pony.cjs"
+    "./url-pattern": {
+      "import": "./dist/url-pattern.js",
+      "require": "./dist/url-pattern.cjs"
     },
     ".": {
       "import": "./index.js",
@@ -54,8 +54,8 @@
   },
   "scripts": {
     "prebuild": "rimraf dist",
-    "build:esm": "esbuild --bundle --format=esm src/url-pattern.ts --outfile=dist/pony.js",
-    "build:cjs": "esbuild --bundle --format=cjs src/url-pattern.ts --outfile=dist/pony.cjs",
+    "build:esm": "esbuild --bundle --format=esm src/url-pattern.ts --outfile=dist/url-pattern.js",
+    "build:cjs": "esbuild --bundle --format=cjs src/url-pattern.ts --outfile=dist/url-pattern.cjs",
     "copy:dts": "cp ./src/index.d.ts ./src/types.d.ts ./dist",
     "build": "npm run build:esm && npm run build:cjs && npm run copy:dts",
     "pretest": "npm run build; rm -rf node_modules/urlpattern-polyfill; ln -s $(pwd) node_modules/urlpattern-polyfill",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,18 @@
     "url": "https://github.com/kenchris/urlpattern-polyfill"
   },
   "type": "module",
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
+  "main": "./index.cjs",
+  "module": "./index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    "import": "./dist/index.js",
-    "require": "./dist/index.cjs"
+    "./pony": {
+      "import": "./dist/pony.js",
+      "require": "./dist/pony.cjs"
+    },
+    ".": {
+      "import": "./index.js",
+      "require": "./index.cjs"
+    }
   },
   "tags": [
     "url",
@@ -48,11 +54,11 @@
   },
   "scripts": {
     "prebuild": "rimraf dist",
-    "build:esm": "esbuild --bundle --format=esm src/patch-global.mts --outfile=dist/index.js",
-    "build:cjs": "esbuild --bundle --format=cjs src/patch-global.cts --outfile=dist/index.cjs",
-    "copy:dts": "cp ./src/index.d.ts ./dist",
+    "build:esm": "esbuild --bundle --format=esm src/url-pattern.ts --outfile=dist/pony.js",
+    "build:cjs": "esbuild --bundle --format=cjs src/url-pattern.ts --outfile=dist/pony.cjs",
+    "copy:dts": "cp ./src/index.d.ts ./src/types.d.ts ./dist",
     "build": "npm run build:esm && npm run build:cjs && npm run copy:dts",
-    "pretest": "npm run build",
+    "pretest": "npm run build; rm -rf node_modules/urlpattern-polyfill; ln -s $(pwd) node_modules/urlpattern-polyfill",
     "test": "ava --fail-fast -s",
     "manual-test": "npx http-server -o /index.html -p 4203",
     "publish-dev": "npm test && VERSION=${npm_package_version%-*}-dev.`git rev-parse --short HEAD` && npm version --no-git-tag-version $VERSION && npm publish --tag dev"

--- a/package.json
+++ b/package.json
@@ -11,9 +11,9 @@
   "module": "./index.js",
   "types": "./dist/index.d.ts",
   "exports": {
-    "./url-pattern": {
-      "import": "./dist/url-pattern.js",
-      "require": "./dist/url-pattern.cjs"
+    "./urlpattern": {
+      "import": "./dist/urlpattern.js",
+      "require": "./dist/urlpattern.cjs"
     },
     ".": {
       "import": "./index.js",
@@ -54,8 +54,8 @@
   },
   "scripts": {
     "prebuild": "rimraf dist",
-    "build:esm": "esbuild --bundle --format=esm src/url-pattern.ts --outfile=dist/url-pattern.js",
-    "build:cjs": "esbuild --bundle --format=cjs src/url-pattern.ts --outfile=dist/url-pattern.cjs",
+    "build:esm": "esbuild --bundle --format=esm src/url-pattern.ts --outfile=dist/urlpattern.js",
+    "build:cjs": "esbuild --bundle --format=cjs src/url-pattern.ts --outfile=dist/urlpattern.cjs",
     "copy:dts": "cp ./src/index.d.ts ./src/types.d.ts ./dist",
     "build": "npm run build:esm && npm run build:cjs && npm run copy:dts",
     "pretest": "npm run build; rm -rf node_modules/urlpattern-polyfill; ln -s $(pwd) node_modules/urlpattern-polyfill",

--- a/pony/package.json
+++ b/pony/package.json
@@ -1,0 +1,5 @@
+{
+  "main": "../dist/pony.cjs",
+  "module": "../dist/pony.js",
+  "types": "../dist/types.d.ts"
+}

--- a/pony/package.json
+++ b/pony/package.json
@@ -1,5 +1,0 @@
-{
-  "main": "../dist/pony.cjs",
-  "module": "../dist/pony.js",
-  "types": "../dist/types.d.ts"
-}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,53 +1,8 @@
-export {};
+import type * as Types from "./types";
 
 declare global {
- type URLPatternInput = URLPatternInit | string;
-
-  class URLPattern {
-    constructor(init?: URLPatternInput, baseURL?: string);
-
-    test(input?: URLPatternInput, baseURL?: string): boolean;
-
-    exec(input?: URLPatternInput, baseURL?: string): URLPatternResult | null;
-
-    readonly protocol: string;
-    readonly username: string;
-    readonly password: string;
-    readonly hostname: string;
-    readonly port: string;
-    readonly pathname: string;
-    readonly search: string;
-    readonly hash: string;
-  }
-
-  interface URLPatternInit {
-    baseURL?: string;
-    username?: string;
-    password?: string;
-    protocol?: string;
-    hostname?: string;
-    port?: string;
-    pathname?: string;
-    search?: string;
-    hash?: string;
-  }
-
-  interface URLPatternResult {
-    inputs: [URLPatternInput];
-    protocol: URLPatternComponentResult;
-    username: URLPatternComponentResult;
-    password: URLPatternComponentResult;
-    hostname: URLPatternComponentResult;
-    port: URLPatternComponentResult;
-    pathname: URLPatternComponentResult;
-    search: URLPatternComponentResult;
-    hash: URLPatternComponentResult;
-  }
-
-  interface URLPatternComponentResult {
-    input: string;
-    groups: {
-        [key: string]: string | undefined;
-    };
-  }
+  class URLPattern extends Types.URLPattern {}
+  type URLPatternInit = Types.URLPatternInit;
+  type URLPatternResult = Types.URLPatternResult;
+  type URLPatternComponentResult = Types.URLPatternComponentResult;
 }

--- a/src/patch-global.mts
+++ b/src/patch-global.mts
@@ -1,6 +1,0 @@
-import { URLPattern } from "./url-pattern";
-export { URLPattern };
-
-if (!globalThis.URLPattern) {
-  globalThis.URLPattern = URLPattern;
-}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,0 +1,49 @@
+export type URLPatternInput = URLPatternInit | string;
+
+export declare class URLPattern {
+  constructor(init?: URLPatternInput, baseURL?: string);
+
+  test(input?: URLPatternInput, baseURL?: string): boolean;
+
+  exec(input?: URLPatternInput, baseURL?: string): URLPatternResult | null;
+
+  readonly protocol: string;
+  readonly username: string;
+  readonly password: string;
+  readonly hostname: string;
+  readonly port: string;
+  readonly pathname: string;
+  readonly search: string;
+  readonly hash: string;
+}
+
+interface URLPatternInit {
+  baseURL?: string;
+  username?: string;
+  password?: string;
+  protocol?: string;
+  hostname?: string;
+  port?: string;
+  pathname?: string;
+  search?: string;
+  hash?: string;
+}
+
+export interface URLPatternResult {
+  inputs: [URLPatternInput];
+  protocol: URLPatternComponentResult;
+  username: URLPatternComponentResult;
+  password: URLPatternComponentResult;
+  hostname: URLPatternComponentResult;
+  port: URLPatternComponentResult;
+  pathname: URLPatternComponentResult;
+  search: URLPatternComponentResult;
+  hash: URLPatternComponentResult;
+}
+
+export interface URLPatternComponentResult {
+  input: string;
+  groups: {
+    [key: string]: string | undefined;
+  };
+}

--- a/test/can-load-as-esm.mjs
+++ b/test/can-load-as-esm.mjs
@@ -1,17 +1,16 @@
-import "../dist/index.js";
-import  test  from "ava";
+import "urlpattern-polyfill";
+import test from "ava";
 
-const baseURL = 'https://example.com';
+const baseURL = "https://example.com";
 
-
-test('urlPattern', t => {
-  let pattern = new URLPattern({baseURL, pathname: '/product/*?'});
-  t.true(pattern.test(baseURL + '/product/a/b'));
+test("urlPattern", (t) => {
+  let pattern = new URLPattern({ baseURL, pathname: "/product/*?" });
+  t.true(pattern.test(baseURL + "/product/a/b"));
 });
 
-test('export of urlPattern there?', async t => {
+test("export of urlPattern there?", async (t) => {
   /** overwrite global wil local version imported, so we know the export is in place */
-  const {URLPattern} = await import("../dist/index.js");
-  let pattern = new URLPattern({baseURL, pathname: '/product/*?'});
-  t.true(pattern.test(baseURL + '/product/a/b'));
-})
+  const { URLPattern } = await import("urlpattern-polyfill");
+  let pattern = new URLPattern({ baseURL, pathname: "/product/*?" });
+  t.true(pattern.test(baseURL + "/product/a/b"));
+});

--- a/test/can-load-as-ts.ts
+++ b/test/can-load-as-ts.ts
@@ -1,14 +1,14 @@
-require( "../dist/index.cjs");
-const test = require( "ava"); 
+require("urlpattern-polyfill");
+const test = require("ava");
 
-const baseURL = 'https://example.com';
+const baseURL = "https://example.com";
 
-test('urlPattern', t => {
-  let pattern = new URLPattern({baseURL, pathname: '/product/*?'});
-  t.true(pattern.test(baseURL + '/product/a/b'));
+test("urlPattern", (t) => {
+  let pattern = new URLPattern({ baseURL, pathname: "/product/*?" });
+  t.true(pattern.test(baseURL + "/product/a/b"));
 });
 
-test('exports urlPattern', t => {
-  const { URLPattern } = require('../dist/index.cjs');
-  t.true(typeof URLPattern === 'function');
-})
+test("exports urlPattern", (t) => {
+  const { URLPattern } = require("urlpattern-polyfill");
+  t.true(typeof URLPattern === "function");
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,15 +1,15 @@
-import test from 'ava';
-import { readFileSync } from 'fs';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import test from "ava";
+import { readFileSync } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
 
 import { runTests } from "./wpt/wpt-test-runner.js";
 
-import '../dist/index.js';
+import "urlpattern-polyfill";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const baseURL = 'https://example.com';
+const baseURL = "https://example.com";
 
 /*
 test('shorthands 1', t => {
@@ -84,7 +84,7 @@ test('JavaScript URL routing 2/2', t => {
 });
 */
 
-let rawdata = readFileSync(path.resolve(__dirname, 'urlpatterntestdata.json'));
+let rawdata = readFileSync(path.resolve(__dirname, "urlpatterntestdata.json"));
 let data = JSON.parse(rawdata);
 
 runTests(data, test);

--- a/test/ponyfill.cjs
+++ b/test/ponyfill.cjs
@@ -1,5 +1,5 @@
 const test = require("ava");
-const { URLPattern } = require("urlpattern-polyfill/pony");
+const { URLPattern } = require("urlpattern-polyfill/url-pattern");
 
 const baseURL = "https://example.com";
 

--- a/test/ponyfill.cjs
+++ b/test/ponyfill.cjs
@@ -1,5 +1,5 @@
 const test = require("ava");
-const { URLPattern } = require("urlpattern-polyfill/url-pattern");
+const { URLPattern } = require("urlpattern-polyfill/urlpattern");
 
 const baseURL = "https://example.com";
 

--- a/test/ponyfill.cjs
+++ b/test/ponyfill.cjs
@@ -1,5 +1,5 @@
-require("urlpattern-polyfill");
 const test = require("ava");
+const { URLPattern } = require("urlpattern-polyfill/pony");
 
 const baseURL = "https://example.com";
 
@@ -8,7 +8,6 @@ test("urlPattern", (t) => {
   t.true(pattern.test(baseURL + "/product/a/b"));
 });
 
-test("exports urlPattern", (t) => {
-  const { URLPattern } = require("urlpattern-polyfill");
-  t.true(typeof URLPattern === "function");
+test("does not pollute global scope", (t) => {
+  t.true(typeof globalThis.URLPattern === "undefined");
 });

--- a/test/ponyfill.mjs
+++ b/test/ponyfill.mjs
@@ -1,5 +1,5 @@
 import test from "ava";
-import { URLPattern } from "urlpattern-polyfill/url-pattern";
+import { URLPattern } from "urlpattern-polyfill/urlpattern";
 
 const baseURL = "https://example.com";
 

--- a/test/ponyfill.mjs
+++ b/test/ponyfill.mjs
@@ -1,5 +1,5 @@
 import test from "ava";
-import { URLPattern } from "urlpattern-polyfill/pony";
+import { URLPattern } from "urlpattern-polyfill/url-pattern";
 
 const baseURL = "https://example.com";
 

--- a/test/ponyfill.mjs
+++ b/test/ponyfill.mjs
@@ -1,5 +1,5 @@
-require("urlpattern-polyfill");
-const test = require("ava");
+import test from "ava";
+import { URLPattern } from "urlpattern-polyfill/pony";
 
 const baseURL = "https://example.com";
 
@@ -8,7 +8,6 @@ test("urlPattern", (t) => {
   t.true(pattern.test(baseURL + "/product/a/b"));
 });
 
-test("exports urlPattern", (t) => {
-  const { URLPattern } = require("urlpattern-polyfill");
-  t.true(typeof URLPattern === "function");
+test("does not pollute global scope", (t) => {
+  t.true(typeof globalThis.URLPattern === "undefined");
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,8 +14,6 @@
     "noImplicitReturns": false,
     "noFallthroughCasesInSwitch": true
   },
-  "include": [
-    "src/**/*.ts"
-  ],
+  "include": ["src/**/*.ts"],
   "exclude": []
 }

--- a/url-pattern/package.json
+++ b/url-pattern/package.json
@@ -1,5 +1,0 @@
-{
-  "main": "../dist/url-pattern.cjs",
-  "module": "../dist/url-pattern.js",
-  "types": "../dist/types.d.ts"
-}

--- a/url-pattern/package.json
+++ b/url-pattern/package.json
@@ -1,0 +1,5 @@
+{
+  "main": "../dist/url-pattern.cjs",
+  "module": "../dist/url-pattern.js",
+  "types": "../dist/types.d.ts"
+}

--- a/urlpattern/package.json
+++ b/urlpattern/package.json
@@ -1,0 +1,5 @@
+{
+  "main": "../dist/urlpattern.cjs",
+  "module": "../dist/urlpattern.js",
+  "types": "../dist/types.d.ts"
+}


### PR DESCRIPTION
This PR introduces a new exported path: `import 'urlpattern-polyfill/pony'` that will not pollute the global scope and will _always_ provide the polyfill implementation.

Notes:

- Importing `urlpattern-polyfill` will pollute the global scope both in runtime and in TypeScript
- Importing `urlpattern-polyfill/pony` will not pollute the global scope at all

Related:

- This supersedes #91
