### PR TITLE
fix: include `index.{js,cjs}` in `file` of `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
     "wicg"
   ],
   "files": [
-    "dist"
+    "dist",
+    "index.js",
+    "index.cjs"
   ],
   "devDependencies": {
     "@ava/typescript": "^3.0.1",


### PR DESCRIPTION
Otherwise Node and bundlers failed to find the entries