### PR TITLE
feat: case-insensitive match for pathname

### DIFF
--- a/src/path-to-regex-modified.ts
+++ b/src/path-to-regex-modified.ts
@@ -329,9 +329,9 @@ export function parse(str: string, options: ParseOptions = {}): Token[] {
 
 export interface TokensToFunctionOptions {
   /**
-   * When `true` the regexp will be case sensitive. (default: `false`)
+   * When `true` the regexp will be case insensitive. (default: `false`)
    */
-  sensitive?: boolean;
+  ignoreCase?: boolean;
   /**
    * Function for encoding input strings for output.
    */
@@ -523,8 +523,8 @@ function escapeString(str: string) {
 /**
  * Get the flags for a regexp from the options.
  */
-function flags(options?: { sensitive?: boolean }) {
-  return options && options.sensitive ? "u" : "ui";
+function flags(options?: { ignoreCase?: boolean }) {
+  return options && options.ignoreCase ? "ui" : "u";
 }
 
 /**
@@ -593,9 +593,9 @@ function stringToRegexp(
 
 export interface TokensToRegexpOptions {
   /**
-   * When `true` the regexp will be case sensitive. (default: `false`)
+   * When `true` the regexp will be case insensitive. (default: `false`)
    */
-  sensitive?: boolean;
+  ignoreCase?: boolean;
   /**
    * When `true` the regexp won't allow an optional trailing delimiter to match. (default: `false`)
    */

--- a/src/url-pattern.interfaces.ts
+++ b/src/url-pattern.interfaces.ts
@@ -8,9 +8,10 @@ export interface URLPatternInit {
   pathname?: string;
   search?: string;
   hash?: string;
+  caseSensitivePath?: boolean;
 }
 
-export type URLPatternKeys = keyof URLPatternInit
+export type URLPatternKeys = Exclude<keyof URLPatternInit, 'caseSensitivePath'>
 
 export interface URLPatternResult {
   inputs: [URLPatternInit | string];

--- a/src/url-pattern.interfaces.ts
+++ b/src/url-pattern.interfaces.ts
@@ -8,7 +8,6 @@ export interface URLPatternInit {
   pathname?: string;
   search?: string;
   hash?: string;
-  caseSensitivePath?: boolean;
 }
 
 export type URLPatternKeys = Exclude<keyof URLPatternInit, 'caseSensitivePath'>
@@ -28,4 +27,8 @@ export interface URLPatternResult {
 export interface URLPatternComponentResult {
   input: string;
   groups: { [key: string]: string };
+}
+
+export interface URLPatternOptions {
+  ignoreCase: boolean;
 }

--- a/src/url-pattern.ts
+++ b/src/url-pattern.ts
@@ -138,6 +138,10 @@ function applyInit(o: URLPatternInit, init: URLPatternInit, isPattern: boolean):
     o.hash = canonicalizeHash(init.hash, isPattern);
   }
 
+  if (typeof init.caseSensitivePath === 'boolean') {
+    o.caseSensitivePath = init.caseSensitivePath;
+  }
+
   return o;
 }
 
@@ -332,7 +336,7 @@ export class URLPattern {
         throw new TypeError(`parameter 1 is not of type 'string' and cannot convert to dictionary.`);
       }
 
-      const defaults = {
+      const defaults: URLPatternInit = {
         pathname: DEFAULT_PATTERN,
         protocol: DEFAULT_PATTERN,
         username: DEFAULT_PATTERN,
@@ -341,6 +345,7 @@ export class URLPattern {
         port: DEFAULT_PATTERN,
         search: DEFAULT_PATTERN,
         hash: DEFAULT_PATTERN,
+        caseSensitivePath: true,
       };
 
       this.pattern = applyInit(defaults, init, true);
@@ -385,11 +390,12 @@ export class URLPattern {
             options.encodePart = portEncodeCallback;
             break;
           case 'pathname':
+            const sensitiveOptions = { sensitive: this.pattern.caseSensitivePath };
             if (isSpecialScheme(this.regexp.protocol)) {
-              Object.assign(options, PATHNAME_OPTIONS);
+              Object.assign(options, PATHNAME_OPTIONS, sensitiveOptions);
               options.encodePart = standardURLPathnameEncodeCallback;
             } else {
-              Object.assign(options, DEFAULT_OPTIONS);
+              Object.assign(options, DEFAULT_OPTIONS, sensitiveOptions);
               options.encodePart = pathURLPathnameEncodeCallback;
             }
             break;
@@ -447,8 +453,8 @@ export class URLPattern {
       return false;
     }
 
-    let component:URLPatternKeys
-    for (component in this.pattern) {
+    let component: URLPatternKeys;
+    for (component of COMPONENTS) {
       if (!this.regexp[component].exec(values[component])) {
         return false;
       }
@@ -496,7 +502,7 @@ export class URLPattern {
     }
 
     let component: URLPatternKeys;
-    for (component in this.pattern) {
+    for (component of COMPONENTS) {
       let match = this.regexp[component].exec(values[component]);
       if (!match) {
         return null;

--- a/test/urlpatterntestdata.json
+++ b/test/urlpatterntestdata.json
@@ -836,29 +836,29 @@
   },
 
   {
-    "pattern": [{ "pathname": "/foo/bar", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo/baR" }],
     "expected_match": {
       "pathname": { "input": "/fOo/baR", "groups": {} }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/bar", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/ba" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/bar", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/bar/" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/bar", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/bar/baz" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/bar", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar"}, {"ignoreCase": true}],
     "inputs": [ "https://example.com/fOo/baR" ],
     "expected_match": {
       "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
@@ -867,12 +867,12 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/bar", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar"}, {"ignoreCase": true}],
     "inputs": [ "https://example.com/foo/bar/baz" ],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/bar", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar"}, {"ignoreCase": true}],
     "inputs": [{ "hostname": "example.com", "pathname": "/fOo/baR" }],
     "expected_match": {
       "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
@@ -880,12 +880,12 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/bar", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar"}, {"ignoreCase": true}],
     "inputs": [{ "hostname": "example.com", "pathname": "/foo/bar/baz" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/bar", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo/baR", "baseURL": "https://example.com" }],
     "expected_match": {
       "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
@@ -894,38 +894,30 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/bar", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/bar/baz",
                  "baseURL": "https://example.com" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/bar",
-                 "baseURL": "https://example.com?query#hash", 
-                 "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar", "baseURL": "https://example.com?query#hash" }, { "ignoreCase": true }],
     "inputs": [{ "pathname": "/foo/bar" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/bar",
-                 "baseURL": "https://example.com?query#hash", 
-                 "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar", "baseURL": "https://example.com?query#hash"}, { "ignoreCase": true }],
     "inputs": [{ "hostname": "example.com", "pathname": "/foo/bar" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/bar",
-                 "baseURL": "https://example.com?query#hash", 
-                 "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar", "baseURL": "https://example.com?query#hash"}, { "ignoreCase": true }],
     "inputs": [{ "protocol": "https", "hostname": "example.com",
                  "pathname": "/foo/bar" }],
     "exactly_empty_components": [ "username", "password", "port" ],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/bar",
-                 "baseURL": "https://example.com", 
-                 "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar", "baseURL": "https://example.com"}, { "ignoreCase": true }],
     "inputs": [{ "protocol": "https", "hostname": "example.com",
                  "pathname": "/fOo/baR" }],
     "exactly_empty_components": [ "username", "password", "port", "search",
@@ -937,17 +929,13 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/bar",
-                 "baseURL": "https://example.com", 
-                 "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar", "baseURL": "https://example.com"}, { "ignoreCase": true }],
     "inputs": [{ "protocol": "https", "hostname": "example.com",
                  "pathname": "/foo/bar/baz" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/bar",
-                 "baseURL": "https://example.com?query#hash", 
-                 "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar", "baseURL": "https://example.com?query#hash"}, { "ignoreCase": true }],
     "inputs": [{ "protocol": "https", "hostname": "example.com",
                  "pathname": "/foo/bar", "search": "otherquery",
                  "hash": "otherhash" }],
@@ -955,9 +943,7 @@
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/bar",
-                 "baseURL": "https://example.com", 
-                 "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar","baseURL": "https://example.com"}, { "ignoreCase": true }],
     "inputs": [{ "protocol": "https", "hostname": "example.com",
                  "pathname": "/foo/bar", "search": "otherquery",
                  "hash": "otherhash" }],
@@ -981,25 +967,19 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/bar",
-                 "baseURL": "https://example.com?query#hash", 
-                 "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar", "baseURL": "https://example.com?query#hash"}, { "ignoreCase": true }],
     "inputs": [ "https://example.com/foo/bar" ],
     "exactly_empty_components": [ "username", "password", "port" ],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/bar",
-                 "baseURL": "https://example.com?query#hash", 
-                 "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar", "baseURL": "https://example.com?query#hash"}, { "ignoreCase": true }],
     "inputs": [ "https://example.com/foo/bar?otherquery#otherhash" ],
     "exactly_empty_components": [ "username", "password", "port" ],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/bar",
-                 "baseURL": "https://example.com?query#hash", 
-                 "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar", "baseURL": "https://example.com?query#hash"}, { "ignoreCase": true }],
     "inputs": [ "https://example.com/fOo/baR?query#hash" ],
     "exactly_empty_components": [ "username", "password", "port" ],
     "expected_match": {
@@ -1011,38 +991,28 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/bar",
-                 "baseURL": "https://example.com?query#hash", 
-                 "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar", "baseURL": "https://example.com?query#hash"}, { "ignoreCase": true }],
     "inputs": [ "https://example.com/foo/bar/baz" ],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/bar",
-                 "baseURL": "https://example.com?query#hash", 
-                 "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar", "baseURL": "https://example.com?query#hash"}, { "ignoreCase": true }],
     "inputs": [ "https://other.com/foo/bar" ],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/bar",
-                 "baseURL": "https://example.com?query#hash", 
-                 "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar", "baseURL": "https://example.com?query#hash"}, { "ignoreCase": true }],
     "inputs": [ "http://other.com/foo/bar" ],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/bar",
-                 "baseURL": "https://example.com?query#hash", 
-                 "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar", "baseURL": "https://example.com?query#hash"}, { "ignoreCase": true }],
     "inputs": [{ "pathname": "/foo/bar", "baseURL": "https://example.com" }],
     "exactly_empty_components": [ "username", "password", "port" ],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/bar",
-                 "baseURL": "https://example.com?query#hash", 
-                 "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar", "baseURL": "https://example.com?query#hash"}, { "ignoreCase": true }],
     "inputs": [{ "pathname": "/foo/bar",
                  "baseURL": "https://example.com?query#hash" }],
     "exactly_empty_components": [ "username", "password", "port" ],
@@ -1055,60 +1025,54 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/bar",
-                 "baseURL": "https://example.com?query#hash", 
-                 "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar", "baseURL": "https://example.com?query#hash"}, { "ignoreCase": true }],
     "inputs": [{ "pathname": "/foo/bar/baz",
                  "baseURL": "https://example.com" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/bar",
-                 "baseURL": "https://example.com?query#hash", 
-                 "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar", "baseURL": "https://example.com?query#hash"}, { "ignoreCase": true }],
     "inputs": [{ "pathname": "/foo/bar", "baseURL": "https://other.com" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/bar",
-                 "baseURL": "https://example.com?query#hash", 
-                 "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/bar", "baseURL": "https://example.com?query#hash"}, { "ignoreCase": true }],
     "inputs": [{ "pathname": "/foo/bar", "baseURL": "http://example.com" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/:bar", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/:bar"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo/baR" }],
     "expected_match": {
       "pathname": { "input": "/fOo/baR", "groups": { "bar": "baR" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/([^\\/]+?)", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/([^\\/]+?)"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo/baR" }],
     "expected_match": {
       "pathname": { "input": "/fOo/baR", "groups": { "0": "baR" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/:baR", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/:baR"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo/index.html" }],
     "expected_match": {
       "pathname": { "input": "/fOo/index.html", "groups": { "baR": "index.html" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/:bar", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/:bar"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/bar/" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/:bar", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/:bar"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/(.*)", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/(.*)"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo/baR" }],
     "expected_obj": {
       "pathname": "/foo/*"
@@ -1118,14 +1082,14 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/*", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/*"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo/baR" }],
     "expected_match": {
       "pathname": { "input": "/fOo/baR", "groups": { "0": "baR" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/(.*)", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/(.*)"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo/baR/Baz" }],
     "expected_obj": {
       "pathname": "/foo/*"
@@ -1135,14 +1099,14 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/*", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/*"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/Foo/bar/baz" }],
     "expected_match": {
       "pathname": { "input": "/Foo/bar/baz", "groups": { "0": "bar/baz" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/(.*)", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/(.*)"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/Foo/" }],
     "expected_obj": {
       "pathname": "/foo/*"
@@ -1152,14 +1116,14 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/*", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/*"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/FOO/" }],
     "expected_match": {
       "pathname": { "input": "/FOO/", "groups": { "0": "" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/(.*)", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/(.*)"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo" }],
     "expected_obj": {
       "pathname": "/foo/*"
@@ -1167,45 +1131,45 @@
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/*", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/*"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/:bar(.*)", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/:bar(.*)"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo/bar" }],
     "expected_match": {
       "pathname": { "input": "/fOo/bar", "groups": { "bar": "bar" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/:bar(.*)", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/:bar(.*)"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foO/bar/baz" }],
     "expected_match": {
       "pathname": { "input": "/foO/bar/baz", "groups": { "bar": "bar/baz" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/:bar(.*)", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/:bar(.*)"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo/" }],
     "expected_match": {
       "pathname": { "input": "/fOo/", "groups": { "bar": "" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/:bar(.*)", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/:bar(.*)"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/:bar?", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/:bar?"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/Foo/bar" }],
     "expected_match": {
       "pathname": { "input": "/Foo/bar", "groups": { "bar": "bar" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/:bar?", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/:bar?"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/Foo" }],
     "//": "The `null` below is translated to undefined in the test harness.",
     "expected_match": {
@@ -1213,65 +1177,65 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/:bar?", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/:bar?"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/:bar?", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/:bar?"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foobar" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/:bar?", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/:bar?"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/bar/baz" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/Foo/:bar+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/Foo/:bar+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/bar" }],
     "expected_match": {
       "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/Foo/:bar+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/Foo/:bar+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/bar/baz" }],
     "expected_match": {
       "pathname": { "input": "/foo/bar/baz", "groups": { "bar": "bar/baz" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/:bar+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/:bar+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/:bar+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/:bar+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/:bar+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/:bar+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foobar" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/Foo/:bar*", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/Foo/:bar*"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo/bar" }],
     "expected_match": {
       "pathname": { "input": "/fOo/bar", "groups": { "bar": "bar" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/FoO/:bar*", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/FoO/:bar*"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/bar/baz" }],
     "expected_match": {
       "pathname": { "input": "/foo/bar/baz", "groups": { "bar": "bar/baz" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/Foo/:bar*", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/Foo/:bar*"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo" }],
     "//": "The `null` below is translated to undefined in the test harness.",
     "expected_match": {
@@ -1279,17 +1243,17 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/:bar*", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/:bar*"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/:bar*", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/:bar*"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foobar" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/(.*)?", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/(.*)?"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo/bar" }],
     "expected_obj": {
       "pathname": "/foo/*?"
@@ -1299,14 +1263,14 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/*?", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/*?"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo/bar" }],
     "expected_match": {
       "pathname": { "input": "/fOo/bar", "groups": { "0": "bar" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/(.*)?", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/(.*)?"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo/bar/baz" }],
     "expected_obj": {
       "pathname": "/foo/*?"
@@ -1316,14 +1280,14 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/Foo/*?", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/Foo/*?"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/bar/baz" }],
     "expected_match": {
       "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/Foo/(.*)?", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/Foo/(.*)?"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo" }],
     "expected_obj": {
       "pathname": "/Foo/*?"
@@ -1334,7 +1298,7 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/*?", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/*?"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo" }],
     "//": "The `null` below is translated to undefined in the test harness.",
     "expected_match": {
@@ -1342,7 +1306,7 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/(.*)?", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/(.*)?"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo/" }],
     "expected_obj": {
       "pathname": "/foo/*?"
@@ -1352,14 +1316,14 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/*?", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/*?"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo/" }],
     "expected_match": {
       "pathname": { "input": "/fOo/", "groups": { "0": "" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/(.*)?", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/(.*)?"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foobar" }],
     "expected_obj": {
       "pathname": "/foo/*?"
@@ -1367,12 +1331,12 @@
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/*?", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/*?"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foobar" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/(.*)?", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/(.*)?"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fo" }],
     "expected_obj": {
       "pathname": "/foo/*?"
@@ -1380,12 +1344,12 @@
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/*?", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/*?"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fo" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/(.*)+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/(.*)+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo/bar" }],
     "expected_obj": {
       "pathname": "/foo/*+"
@@ -1395,14 +1359,14 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/*+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/*+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo/bar" }],
     "expected_match": {
       "pathname": { "input": "/fOo/bar", "groups": { "0": "bar" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/Foo/(.*)+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/Foo/(.*)+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/Foo/bar/baz" }],
     "expected_obj": {
       "pathname": "/Foo/*+"
@@ -1412,14 +1376,14 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/*+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/*+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo/bar/baz" }],
     "expected_match": {
       "pathname": { "input": "/fOo/bar/baz", "groups": { "0": "bar/baz" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/(.*)+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/(.*)+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo" }],
     "expected_obj": {
       "pathname": "/foo/*+"
@@ -1427,12 +1391,12 @@
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/*+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/*+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foO/(.*)+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foO/(.*)+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/" }],
     "expected_obj": {
       "pathname": "/foO/*+"
@@ -1442,14 +1406,14 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foO/*+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foO/*+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/" }],
     "expected_match": {
       "pathname": { "input": "/foo/", "groups": { "0": "" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/(.*)+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/(.*)+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foobar" }],
     "expected_obj": {
       "pathname": "/foo/*+"
@@ -1457,12 +1421,12 @@
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/*+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/*+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foobar" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/(.*)+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/(.*)+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fo" }],
     "expected_obj": {
       "pathname": "/foo/*+"
@@ -1470,12 +1434,12 @@
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/*+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/*+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fo" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foO/(.*)*", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foO/(.*)*"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foO/baR" }],
     "expected_obj": {
       "pathname": "/foO/**"
@@ -1485,14 +1449,14 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/Foo/**", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/Foo/**"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/bar" }],
     "expected_match": {
       "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/Foo/(.*)*", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/Foo/(.*)*"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/bar/baz" }],
     "expected_obj": {
       "pathname": "/Foo/**"
@@ -1502,14 +1466,14 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/**", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/**"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foO/bar/baz" }],
     "expected_match": {
       "pathname": { "input": "/foO/bar/baz", "groups": { "0": "bar/baz" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/Foo/(.*)*", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/Foo/(.*)*"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo" }],
     "expected_obj": {
       "pathname": "/Foo/**"
@@ -1520,7 +1484,7 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/**", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/**"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo" }],
     "//": "The `null` below is translated to undefined in the test harness.",
     "expected_match": {
@@ -1528,7 +1492,7 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foO/(.*)*", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foO/(.*)*"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/" }],
     "expected_obj": {
       "pathname": "/foO/**"
@@ -1538,14 +1502,14 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foO/**", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foO/**"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/" }],
     "expected_match": {
       "pathname": { "input": "/foo/", "groups": { "0": "" } }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo/(.*)*", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/(.*)*"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foobar" }],
     "expected_obj": {
       "pathname": "/foo/**"
@@ -1553,12 +1517,12 @@
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/**", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/**"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foobar" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/(.*)*", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/(.*)*"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fo" }],
     "expected_obj": {
       "pathname": "/foo/**"
@@ -1566,12 +1530,12 @@
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo/**", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo/**"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fo" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo{/bar}", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo{/bar}"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foO/baR" }],
     "expected_obj": {
       "pathname": "/foo/bar"
@@ -1581,7 +1545,7 @@
     }
   },
   {
-    "pattern": [{ "pathname": "/foo{/bar}", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo{/bar}"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/bar/baz" }],
     "expected_obj": {
       "pathname": "/foo/bar"
@@ -1589,7 +1553,7 @@
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo{/bar}", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo{/bar}"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo" }],
     "expected_obj": {
       "pathname": "/foo/bar"
@@ -1597,7 +1561,7 @@
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo{/bar}", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo{/bar}"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/" }],
     "expected_obj": {
       "pathname": "/foo/bar"
@@ -1605,86 +1569,86 @@
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo{/bar}?", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo{/bar}?"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/Foo/bAr" }],
     "expected_match": {
       "pathname": { "input": "/Foo/bAr", "groups": {} }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo{/bar}?", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo{/bar}?"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/bar/baz" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo{/bar}?", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo{/bar}?"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/fOo" }],
     "expected_match": {
       "pathname": { "input": "/fOo", "groups": {} }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo{/bar}?", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo{/bar}?"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo{/bar}+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo{/bar}+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/Foo/bar" }],
     "expected_match": {
       "pathname": { "input": "/Foo/bar", "groups": {} }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo{/bar}+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo{/bar}+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/Foo/bAr/baR" }],
     "expected_match": {
       "pathname": { "input": "/Foo/bAr/baR", "groups": {} }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo{/bar}+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo{/bar}+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/bar/baz" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo{/bar}+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo{/bar}+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo{/bar}+", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo{/bar}+"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo{/bar}*", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo{/bar}*"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foO/Bar" }],
     "expected_match": {
       "pathname": { "input": "/foO/Bar", "groups": {} }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo{/bar}*", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo{/bar}*"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/Foo/bAr/baR" }],
     "expected_match": {
       "pathname": { "input": "/Foo/bAr/baR", "groups": {} }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo{/bar}*", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo{/bar}*"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/bar/baz" }],
     "expected_match": null
   },
   {
-    "pattern": [{ "pathname": "/foo{/bar}*", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo{/bar}*"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/Foo" }],
     "expected_match": {
       "pathname": { "input": "/Foo", "groups": {} }
     }
   },
   {
-    "pattern": [{ "pathname": "/foo{/bar}*", "caseSensitivePath": false }],
+    "pattern": [{ "pathname": "/foo{/bar}*"}, {"ignoreCase": true}],
     "inputs": [{ "pathname": "/foo/" }],
     "expected_match": null
   },
@@ -1760,10 +1724,24 @@
     }
   },
   {
+    "pattern": [{ "search": "q1=:café" }, {"ignoreCase": true}],
+    "inputs": [{ "search": "Q1=foo" }],
+    "expected_match": {
+      "search": { "input": "Q1=foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
     "pattern": [{ "hash": ":café" }],
     "inputs": [{ "hash": "foo" }],
     "expected_match": {
       "hash": { "input": "foo", "groups": { "café": "foo" } }
+    }
+  },
+  {
+    "pattern": [{ "hash": "bar-:café" }, {"ignoreCase": true}],
+    "inputs": [{ "hash": "BaR-foo" }],
+    "expected_match": {
+      "hash": { "input": "BaR-foo", "groups": { "café": "foo" } }
     }
   },
   {
@@ -2354,6 +2332,25 @@
       "pathname": { "input": "/foo", "groups": {} },
       "search": { "input": "bar", "groups": {} },
       "hash": { "input": "baz", "groups": {} }
+    }
+  },
+  {
+    "pattern": [ "/foo?bar#baz", "https://example.com:8080", {"ignoreCase": true} ],
+    "inputs": [{ "pathname": "/Foo", "search": "bAr", "hash": "baZ",
+                 "baseURL": "https://example.com:8080" }],
+    "exactly_empty_components": [ "username", "password" ],
+    "expected_obj": {
+      "pathname": "/foo",
+      "search": "bar",
+      "hash": "baz"
+    },
+    "expected_match": {
+      "protocol": { "input": "https", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "port": { "input": "8080", "groups": {} },
+      "pathname": { "input": "/Foo", "groups": {} },
+      "search": { "input": "bAr", "groups": {} },
+      "hash": { "input": "baZ", "groups": {} }
     }
   },
   {

--- a/test/urlpatterntestdata.json
+++ b/test/urlpatterntestdata.json
@@ -834,6 +834,861 @@
     "inputs": [{ "pathname": "/foo/" }],
     "expected_match": null
   },
+
+  {
+    "pattern": [{ "pathname": "/foo/bar", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo/baR" }],
+    "expected_match": {
+      "pathname": { "input": "/fOo/baR", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/ba" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/bar/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar", "caseSensitivePath": false }],
+    "inputs": [ "https://example.com/fOo/baR" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
+      "pathname": { "input": "/fOo/baR", "groups": {} },
+      "protocol": { "input": "https", "groups": { "0": "https" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar", "caseSensitivePath": false }],
+    "inputs": [ "https://example.com/foo/bar/baz" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar", "caseSensitivePath": false }],
+    "inputs": [{ "hostname": "example.com", "pathname": "/fOo/baR" }],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
+      "pathname": { "input": "/fOo/baR", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar", "caseSensitivePath": false }],
+    "inputs": [{ "hostname": "example.com", "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo/baR", "baseURL": "https://example.com" }],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": { "0": "example.com" } },
+      "pathname": { "input": "/fOo/baR", "groups": {} },
+      "protocol": { "input": "https", "groups": { "0": "https" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/bar/baz",
+                 "baseURL": "https://example.com" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash", 
+                 "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash", 
+                 "caseSensitivePath": false }],
+    "inputs": [{ "hostname": "example.com", "pathname": "/foo/bar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash", 
+                 "caseSensitivePath": false }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar" }],
+    "exactly_empty_components": [ "username", "password", "port" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com", 
+                 "caseSensitivePath": false }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/fOo/baR" }],
+    "exactly_empty_components": [ "username", "password", "port", "search",
+                                  "hash" ],
+    "expected_match": {
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/fOo/baR", "groups": {} },
+      "protocol": { "input": "https", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com", 
+                 "caseSensitivePath": false }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash", 
+                 "caseSensitivePath": false }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar", "search": "otherquery",
+                 "hash": "otherhash" }],
+    "exactly_empty_components": [ "username", "password", "port" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com", 
+                 "caseSensitivePath": false }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar", "search": "otherquery",
+                 "hash": "otherhash" }],
+    "exactly_empty_components": [ "username", "password", "port", "search",
+                                  "hash" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?otherquery#otherhash" }],
+    "inputs": [{ "protocol": "https", "hostname": "example.com",
+                 "pathname": "/foo/bar", "search": "otherquery",
+                 "hash": "otherhash" }],
+    "exactly_empty_components": [ "username", "password", "port" ],
+    "expected_match": {
+      "hash": { "input": "otherhash", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "otherquery", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash", 
+                 "caseSensitivePath": false }],
+    "inputs": [ "https://example.com/foo/bar" ],
+    "exactly_empty_components": [ "username", "password", "port" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash", 
+                 "caseSensitivePath": false }],
+    "inputs": [ "https://example.com/foo/bar?otherquery#otherhash" ],
+    "exactly_empty_components": [ "username", "password", "port" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash", 
+                 "caseSensitivePath": false }],
+    "inputs": [ "https://example.com/fOo/baR?query#hash" ],
+    "exactly_empty_components": [ "username", "password", "port" ],
+    "expected_match": {
+      "hash": { "input": "hash", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/fOo/baR", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "query", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash", 
+                 "caseSensitivePath": false }],
+    "inputs": [ "https://example.com/foo/bar/baz" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash", 
+                 "caseSensitivePath": false }],
+    "inputs": [ "https://other.com/foo/bar" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash", 
+                 "caseSensitivePath": false }],
+    "inputs": [ "http://other.com/foo/bar" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash", 
+                 "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/bar", "baseURL": "https://example.com" }],
+    "exactly_empty_components": [ "username", "password", "port" ],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash", 
+                 "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash" }],
+    "exactly_empty_components": [ "username", "password", "port" ],
+    "expected_match": {
+      "hash": { "input": "hash", "groups": {} },
+      "hostname": { "input": "example.com", "groups": {} },
+      "pathname": { "input": "/foo/bar", "groups": {} },
+      "protocol": { "input": "https", "groups": {} },
+      "search": { "input": "query", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash", 
+                 "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/bar/baz",
+                 "baseURL": "https://example.com" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash", 
+                 "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/bar", "baseURL": "https://other.com" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/bar",
+                 "baseURL": "https://example.com?query#hash", 
+                 "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/bar", "baseURL": "http://example.com" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo/baR" }],
+    "expected_match": {
+      "pathname": { "input": "/fOo/baR", "groups": { "bar": "baR" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/([^\\/]+?)", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo/baR" }],
+    "expected_match": {
+      "pathname": { "input": "/fOo/baR", "groups": { "0": "baR" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:baR", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo/index.html" }],
+    "expected_match": {
+      "pathname": { "input": "/fOo/index.html", "groups": { "baR": "index.html" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/bar/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo/baR" }],
+    "expected_obj": {
+      "pathname": "/foo/*"
+    },
+    "expected_match": {
+      "pathname": { "input": "/fOo/baR", "groups": { "0": "baR" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo/baR" }],
+    "expected_match": {
+      "pathname": { "input": "/fOo/baR", "groups": { "0": "baR" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo/baR/Baz" }],
+    "expected_obj": {
+      "pathname": "/foo/*"
+    },
+    "expected_match": {
+      "pathname": { "input": "/fOo/baR/Baz", "groups": { "0": "baR/Baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/Foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/Foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/Foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/*"
+    },
+    "expected_match": {
+      "pathname": { "input": "/Foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/FOO/" }],
+    "expected_match": {
+      "pathname": { "input": "/FOO/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/*"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar(.*)", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/fOo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar(.*)", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foO/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foO/bar/baz", "groups": { "bar": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar(.*)", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo/" }],
+    "expected_match": {
+      "pathname": { "input": "/fOo/", "groups": { "bar": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar(.*)", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/Foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/Foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/Foo" }],
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/Foo", "groups": { "bar": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar?", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/Foo/:bar+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/Foo/:bar+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "bar": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/Foo/:bar*", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/fOo/bar", "groups": { "bar": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/FoO/:bar*", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "bar": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/Foo/:bar*", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo" }],
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "bar": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/:bar*", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": {
+      "pathname": { "input": "/fOo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/fOo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": {
+      "pathname": { "input": "/fOo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/Foo/*?", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/Foo/(.*)?", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/Foo/*?"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "0": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo" }],
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/fOo", "groups": { "0": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo/" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": {
+      "pathname": { "input": "/fOo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo/" }],
+    "expected_match": {
+      "pathname": { "input": "/fOo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)?", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_obj": {
+      "pathname": "/foo/*?"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*?", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo/bar" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": {
+      "pathname": { "input": "/fOo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/fOo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/Foo/(.*)+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/Foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/Foo/*+"
+    },
+    "expected_match": {
+      "pathname": { "input": "/Foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/fOo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foO/(.*)+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foO/*+"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foO/*+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_obj": {
+      "pathname": "/foo/*+"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/*+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foO/(.*)*", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foO/baR" }],
+    "expected_obj": {
+      "pathname": "/foO/**"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foO/baR", "groups": { "0": "baR" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/Foo/**", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/bar", "groups": { "0": "bar" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/Foo/(.*)*", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/Foo/**"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foO/bar/baz" }],
+    "expected_match": {
+      "pathname": { "input": "/foO/bar/baz", "groups": { "0": "bar/baz" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/Foo/(.*)*", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/Foo/**"
+    },
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/foo", "groups": { "0": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo" }],
+    "//": "The `null` below is translated to undefined in the test harness.",
+    "expected_match": {
+      "pathname": { "input": "/fOo", "groups": { "0": null } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foO/(.*)*", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foO/**"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foO/**", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": {
+      "pathname": { "input": "/foo/", "groups": { "0": "" } }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foobar" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/(.*)*", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_obj": {
+      "pathname": "/foo/**"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo/**", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foO/baR" }],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": {
+      "pathname": { "input": "/foO/baR", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_obj": {
+      "pathname": "/foo/bar"
+    },
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}?", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/Foo/bAr" }],
+    "expected_match": {
+      "pathname": { "input": "/Foo/bAr", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}?", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}?", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/fOo" }],
+    "expected_match": {
+      "pathname": { "input": "/fOo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}?", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/Foo/bar" }],
+    "expected_match": {
+      "pathname": { "input": "/Foo/bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/Foo/bAr/baR" }],
+    "expected_match": {
+      "pathname": { "input": "/Foo/bAr/baR", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}+", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foO/Bar" }],
+    "expected_match": {
+      "pathname": { "input": "/foO/Bar", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/Foo/bAr/baR" }],
+    "expected_match": {
+      "pathname": { "input": "/Foo/bAr/baR", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/bar/baz" }],
+    "expected_match": null
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/Foo" }],
+    "expected_match": {
+      "pathname": { "input": "/Foo", "groups": {} }
+    }
+  },
+  {
+    "pattern": [{ "pathname": "/foo{/bar}*", "caseSensitivePath": false }],
+    "inputs": [{ "pathname": "/foo/" }],
+    "expected_match": null
+  },
+
   {
     "pattern": [{ "protocol": "(café)" }],
     "expected_obj": "error"


### PR DESCRIPTION
Related to https://github.com/WICG/urlpattern/issues/148.
This PR adds support for case-insensitive match for `pathname`. It adds a `caseSensitivePath` flag to the init object.

Example:

```ts
import { strictEqual } from 'assert';

const pattern = new URLPattern({ pathname: '/home', caseSensitivePath: false });

const url = new URL('https://example.com/home');
strictEqual(pattern.test(url.href), true, url.href);

url.pathname = '/HOME';
strictEqual(pattern.test(url.href), true, url.href);
```