### PR TITLE
Add "types" to package exports for TypeScript NodeNext

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
   "types": "./dist/index.d.ts",
   "exports": {
     "./urlpattern": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/urlpattern.js",
       "require": "./dist/urlpattern.cjs"
     },
     ".": {
+      "types": "./dist/index.d.ts",      
       "import": "./index.js",
       "require": "./index.cjs"
     }

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,4 @@
-import type * as Types from "./types";
+import type * as Types from "./types.js";
 
 declare global {
   class URLPattern extends Types.URLPattern {}


### PR DESCRIPTION
TypeScript 4.7 has support for package exports, however it requires that each package export entry specifies the typings for that export. If omitted, for a project that is using the new `NodeNext` resolution mode, the typings will not be found: https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing

This PR adds a "types" field to the two export conditions, so that they can be imported when using the `NodeNext` setting in TypeScript 4.7.

It also adds a `.js` extension to `index.d.ts`'s import of `types`, which is also required when consumers are using the new `NodeNext` resolution mode.