### PR TITLE
Add types

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -6,3 +6,5 @@ declare global {
   type URLPatternResult = Types.URLPatternResult;
   type URLPatternComponentResult = Types.URLPatternComponentResult;
 }
+
+export const URLPattern: Types.URLPattern;


### PR DESCRIPTION
You can import `URLPattern` directly like ESM. (It is mensioned in [readme](https://github.com/kenchris/urlpattern-polyfill#loading-as-esm-module) of repo).

```js
import {URLPattern} from "urlpattern-polyfill";
globalThis.URLPattern = URLPattern
```

But typescript type for that is missing.