### PR TITLE
Improve type safety of URLPattern args

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,6 +2,7 @@ import type * as Types from "./types.js";
 
 declare global {
   class URLPattern extends Types.URLPattern {}
+  type URLPatternInput = Types.URLPatternInput;
   type URLPatternInit = Types.URLPatternInit;
   type URLPatternResult = Types.URLPatternResult;
   type URLPatternComponentResult = Types.URLPatternComponentResult;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,7 +2,7 @@ import type * as Types from "./types.js";
 
 declare global {
   class URLPattern extends Types.URLPattern {}
-  type URLPatternInput = Types.URLPatternInput;
+  type URLPatternArgs = Types.URLPatternArgs;
   type URLPatternInit = Types.URLPatternInit;
   type URLPatternResult = Types.URLPatternResult;
   type URLPatternComponentResult = Types.URLPatternComponentResult;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,11 +1,11 @@
-export type URLPatternInput = URLPatternInit | string;
+export type URLPatternArgs =
+  | [URLPatternInit | RegExp | undefined]
+  | [string, string | undefined];
 
 export declare class URLPattern {
-  constructor(init?: URLPatternInput, baseURL?: string);
-
-  test(input?: URLPatternInput, baseURL?: string): boolean;
-
-  exec(input?: URLPatternInput, baseURL?: string): URLPatternResult | null;
+  constructor(...args: URLPatternArgs);
+  test(...args: URLPatternArgs): boolean;
+  exec(...args: URLPatternArgs): URLPatternResult | null;
 
   readonly protocol: string;
   readonly username: string;
@@ -30,7 +30,7 @@ export interface URLPatternInit {
 }
 
 export interface URLPatternResult {
-  inputs: [URLPatternInput];
+  inputs: URLPatternArgs;
   protocol: URLPatternComponentResult;
   username: URLPatternComponentResult;
   password: URLPatternComponentResult;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -18,15 +18,15 @@ export declare class URLPattern {
 }
 
 interface URLPatternInit {
-  baseURL?: string;
+  protocol?: string;
   username?: string;
   password?: string;
-  protocol?: string;
   hostname?: string;
   port?: string;
   pathname?: string;
   search?: string;
   hash?: string;
+  baseURL?: string;
 }
 
 export interface URLPatternResult {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -17,7 +17,7 @@ export declare class URLPattern {
   readonly hash: string;
 }
 
-interface URLPatternInit {
+export interface URLPatternInit {
   protocol?: string;
   username?: string;
   password?: string;


### PR DESCRIPTION
This makes the types closer to the behavior of the polyfill and the Chrome implementation by using a discriminated union to determine if the second arg is allowed, and then sharing the args between methods in a tuple type.

Note that this is a breaking change for TypeScript users, as I wanted to get rid of `URLPatternInput` to improve type safety. If possible, I'd recommend a major release for this.