### PR TITLE
Fix `URLPattern` type export

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,4 +1,5 @@
 import type * as Types from "./types.js";
+export type { URLPattern } from "./types.js";
 
 declare global {
   class URLPattern extends Types.URLPattern {}
@@ -6,5 +7,3 @@ declare global {
   type URLPatternResult = Types.URLPatternResult;
   type URLPatternComponentResult = Types.URLPatternComponentResult;
 }
-
-export const URLPattern: Types.URLPattern;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,5 @@
 import type * as Types from "./types.js";
-export type { URLPattern } from "./types.js";
+export { URLPattern } from "./types.js";
 
 declare global {
   class URLPattern extends Types.URLPattern {}


### PR DESCRIPTION
I've noticed that the current `URLPattern` exported type can't be used as a constructor. In this PR I've changed `index.d.ts` so that we export `URLPattern` directly from `types.js`, which does address the problem.

_Before:_

![Screenshot 2023-03-29 at 18 26 49](https://user-images.githubusercontent.com/4162329/228620282-58d7f1ec-b699-41f5-911c-5045a1a17600.png)

_After:_

![Screenshot 2023-03-29 at 18 25 57](https://user-images.githubusercontent.com/4162329/228620327-49d34dd5-94f2-4a88-acb2-f103567f5b43.png)

