### PR TITLE
use private class fields

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: [16.x, 18.x, 20.x]
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   },
   "wireit": {
     "build:esm": {
-      "command": "esbuild --bundle --format=esm src/url-pattern.ts --outfile=dist/urlpattern.js",
+      "command": "esbuild --bundle --format=esm src/url-pattern.ts --outfile=dist/urlpattern.js --minify --target=es2022",
       "output": [
         "dist/urlpattern.js"
       ],
@@ -80,7 +80,7 @@
       ]
     },
     "build:cjs": {
-      "command": "esbuild --bundle --format=cjs src/url-pattern.ts --outfile=dist/urlpattern.cjs",
+      "command": "esbuild --bundle --format=cjs src/url-pattern.ts --outfile=dist/urlpattern.cjs --minify --target=es2022",
       "output": [
         "dist/urlpattern.cjs"
       ],

--- a/src/url-pattern.ts
+++ b/src/url-pattern.ts
@@ -313,11 +313,11 @@ function partsToPattern(parts: Part[], options: Options & ParseOptions): string 
 }
 
 export class URLPattern {
-  private pattern: URLPatternInit;
-  private regexp: any = {};
-  private names: string[] = {};
-  private component_pattern: any = {};
-  private parts: any = {};
+  #pattern: URLPatternInit;
+  #regexp: any = {};
+  #names: string[] = {};
+  #component_pattern: any = {};
+  #parts: any = {};
 
   constructor(init: URLPatternInit | string, baseURL?: string, options?: URLPatternOptions);
   constructor(init: URLPatternInit | string, options?: URLPatternOptions);
@@ -364,10 +364,10 @@ export class URLPattern {
         hash: DEFAULT_PATTERN,
       };
 
-      this.pattern = applyInit(defaults, init, true);
+      this.#pattern = applyInit(defaults, init, true);
 
-      if (defaultPortForProtocol(this.pattern.protocol) === this.pattern.port) {
-        this.pattern.port = '';
+      if (defaultPortForProtocol(this.#pattern.protocol) === this.#pattern.port) {
+        this.#pattern.port = '';
       }
 
       let component: URLPatternKeys;
@@ -375,11 +375,11 @@ export class URLPattern {
       // before the pathname.  We need to know the protocol in order to know
       // which kind of canonicalization to apply.
       for (component of COMPONENTS) {
-        if (!(component in this.pattern))
+        if (!(component in this.#pattern))
           continue;
         const options: Options & ParseOptions = {};
-        const pattern = this.pattern[component];
-        this.names[component] = [];
+        const pattern = this.#pattern[component];
+        this.#names[component] = [];
         switch (component) {
           case 'protocol':
             Object.assign(options, DEFAULT_OPTIONS);
@@ -406,7 +406,7 @@ export class URLPattern {
             options.encodePart = portEncodeCallback;
             break;
           case 'pathname':
-            if (isSpecialScheme(this.regexp.protocol)) {
+            if (isSpecialScheme(this.#regexp.protocol)) {
               Object.assign(options, PATHNAME_OPTIONS, ignoreCaseOptions);
               options.encodePart = standardURLPathnameEncodeCallback;
             } else {
@@ -424,12 +424,12 @@ export class URLPattern {
             break;
         }
         try {
-          this.parts[component] = parse(pattern as string, options);
-          this.regexp[component] = partsToRegexp(this.parts[component], /* out */ this.names[component], options);
-          this.component_pattern[component] = partsToPattern(this.parts[component], options);
+          this.#parts[component] = parse(pattern as string, options);
+          this.#regexp[component] = partsToRegexp(this.#parts[component], /* out */ this.#names[component], options);
+          this.#component_pattern[component] = partsToPattern(this.#parts[component], options);
         } catch (err) {
           // If a pattern is illegal the constructor will throw an exception
-          throw new TypeError(`invalid ${component} pattern '${this.pattern[component]}'.`);
+          throw new TypeError(`invalid ${component} pattern '${this.#pattern[component]}'.`);
         }
       }
     } catch (err: any) {
@@ -470,7 +470,7 @@ export class URLPattern {
 
     let component: URLPatternKeys;
     for (component of COMPONENTS) {
-      if (!this.regexp[component].exec(values[component])) {
+      if (!this.#regexp[component].exec(values[component])) {
         return false;
       }
     }
@@ -518,13 +518,13 @@ export class URLPattern {
 
     let component: URLPatternKeys;
     for (component of COMPONENTS) {
-      let match = this.regexp[component].exec(values[component]);
+      let match = this.#regexp[component].exec(values[component]);
       if (!match) {
         return null;
       }
 
       let groups = {} as Array<string>;
-      for (let [i, name] of this.names[component].entries()) {
+      for (let [i, name] of this.#names[component].entries()) {
         if (typeof name === 'string' || typeof name === 'number') {
           let value = match[i + 1];
           groups[name] = value;
@@ -609,53 +609,53 @@ export class URLPattern {
 
     // If both the left and right components are empty wildcards, then they are
     // effectively equal.
-    if (!left.component_pattern[component] && !right.component_pattern[component]) {
+    if (!left.#component_pattern[component] && !right.#component_pattern[component]) {
       return 0;
     }
 
     // If one side has a real pattern and the other side is an empty component,
     // then we have to compare to a part list with a single full wildcard.
-    if (left.component_pattern[component] && !right.component_pattern[component]) {
-      return comparePartList(left.parts[component], [wildcardOnlyPart]);
+    if (left.#component_pattern[component] && !right.#component_pattern[component]) {
+      return comparePartList(left.#parts[component], [wildcardOnlyPart]);
     }
 
-    if (!left.component_pattern[component] && right.component_pattern[component]) {
-      return comparePartList([wildcardOnlyPart], right.parts[component]);
+    if (!left.#component_pattern[component] && right.#component_pattern[component]) {
+      return comparePartList([wildcardOnlyPart], right.#parts[component]);
     }
 
     // Otherwise compare the part lists of the patterns on each side.
-    return comparePartList(left.parts[component], right.parts[component]);
+    return comparePartList(left.#parts[component], right.#parts[component]);
   }
 
   public get protocol() {
-    return this.component_pattern.protocol;
+    return this.#component_pattern.protocol;
   }
 
   public get username() {
-    return this.component_pattern.username;
+    return this.#component_pattern.username;
   }
 
   public get password() {
-    return this.component_pattern.password;
+    return this.#component_pattern.password;
   }
 
   public get hostname() {
-    return this.component_pattern.hostname;
+    return this.#component_pattern.hostname;
   }
 
   public get port() {
-    return this.component_pattern.port;
+    return this.#component_pattern.port;
   }
 
   public get pathname() {
-    return this.component_pattern.pathname;
+    return this.#component_pattern.pathname;
   }
 
   public get search() {
-    return this.component_pattern.search;
+    return this.#component_pattern.search;
   }
 
   public get hash() {
-    return this.component_pattern.hash;
+    return this.#component_pattern.hash;
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es2020",
-    "module": "es2020",
+    "target": "es2022",
+    "module": "es2022",
     "lib": ["es2020", "dom"],
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
Because hard private class fields have the '#' prefix rather than a soft typescript-flavored 'private' keyword, esbuild can mangle the names to look like 1-2 letter words.

I changed the esbuild build process to include "—minify —target=es2022," and I then compared the size it produced.

- Before using `#`: 18 637 byte
- After using `#`: 16 127  byte

As you can see, the name has been shortened.

In addition, they shouldn't have ever been made public in the first place.

I prefer using '#' over the TS private keyword since you can tell right away that this, for example:
```js
          if (this.#isHashPrefix()) {
            this.#changeState(State.HASH, /*skip=*/1);
          } else if (this.#isSearchPrefix()) {
            this.#changeState(State.SEARCH, /*skip=*/1);
            this.#internalResult.hash = '';
          } else {
            this.#changeState(State.PATHNAME, /*skip=*/0);
            this.#internalResult.search = '';
            this.#internalResult.hash = '';
          }
```
...is utilizing hidden, private class fields. without having to pause over a variable or check the definitions of x, y, and z to see if the private keyword was used. Also, it won't build d.ts documentation for these items and won't need to construct any "@private" definitions, resulting in smaller d.ts files because you wouldn't even be aware that they existed from the outside.
"#" is a universally understood token or symbol that denotes that something is private. additionally making it tamper-proof.

closes #116 