### PR TITLE
Keep name for better runtime inspection

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
   },
   "wireit": {
     "build:esm": {
-      "command": "esbuild --bundle --format=esm src/url-pattern.ts --outfile=dist/urlpattern.js --minify --target=es2022",
+      "command": "esbuild --bundle --format=esm src/url-pattern.ts --outfile=dist/urlpattern.js --minify --keep-names --target=es2022",
       "output": [
         "dist/urlpattern.js"
       ],
@@ -77,7 +77,7 @@
       ]
     },
     "build:cjs": {
-      "command": "esbuild --bundle --format=cjs src/url-pattern.ts --outfile=dist/urlpattern.cjs --minify --target=es2022",
+      "command": "esbuild --bundle --format=cjs src/url-pattern.ts --outfile=dist/urlpattern.cjs --minify --keep-names --target=es2022",
       "output": [
         "dist/urlpattern.cjs"
       ],

--- a/src/url-pattern.ts
+++ b/src/url-pattern.ts
@@ -462,6 +462,10 @@ export class URLPattern {
     }
   }
 
+  get [Symbol.toStringTag]() {
+    return "URLPattern"
+  }
+
   test(input: string | URLPatternInit = {}, baseURL?: string) {
     let values: URLPatternInit = {
       pathname: '',


### PR DESCRIPTION
1. Previously, `console.log(URLPattern)` would show `[class me]` because of the minification process. Adding `--keep-names` means this will now show as `[class URLPattern]`.

2. Previously, `String(new URLPattern)` would show `[object Object]`. Now it shows `[object URLPattern]`